### PR TITLE
add constraints on allocating components to workplaces on conveyors

### DIFF
--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -612,9 +612,25 @@ class BaseProject(object, metaclass=ABCMeta):
             ready_component = ready_task.target_component
             for workplace in ready_task.allocated_workplace_list:
                 if workplace.ID in target_workplace_id_list:
-                    #"""
-
-                    #"""
+                    if workplace.input_workplace_list != []:                        
+                        if not(
+                            ready_component.placed_workplace == None
+                            or ready_component.placed_workplace == workplace
+                            or ready_component.placed_workplace in workplace.input_workplace_list
+                        ):
+                            continue
+                        cannnot_set_ready_child_component_to_workplace = False
+                        for ready_child_component in ready_component.child_component_list:
+                            if not (
+                                ready_child_component.placed_workplace == None
+                                or ready_child_component.placed_workplace.output_workplace_list == []
+                                or ready_child_component.placed_workplace == workplace
+                                or ready_child_component.placed_workplace in workplace.input_workplace_list
+                            ):
+                                cannnot_set_ready_child_component_to_workplace = True
+                                break
+                        if cannnot_set_ready_child_component_to_workplace:
+                            continue          
                     if (
                         workplace.can_put(ready_component)
                         and workplace.get_total_workamount_skill(ready_task.name)

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -612,6 +612,25 @@ class BaseProject(object, metaclass=ABCMeta):
             ready_component = ready_task.target_component
             for workplace in ready_task.allocated_workplace_list:
                 if workplace.ID in target_workplace_id_list:
+                    if workplace.input_workplace_list != []:
+                        if (
+                            ready_component.placed_workplace != None
+                            and ready_component.placed_workplace != workplace
+                            and ready_component.placed_workplace not in workplace.input_workplace_list
+                        ):
+                            continue
+                        flag = False
+                        for ready_child_component in ready_component.child_component_list:
+                            if (
+                                ready_child_component.placed_workplace != None
+                                and ready_child_component.placed_workplace.output_workplace_list != []
+                                and ready_child_component.placed_workplace != workplace
+                                and ready_child_component.placed_workplace not in workplace.input_workplace_list
+                            ):
+                                flag = True
+                                break
+                        if flag:
+                            continue
                     if (
                         workplace.can_put(ready_component)
                         and workplace.get_total_workamount_skill(ready_task.name)

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -612,25 +612,9 @@ class BaseProject(object, metaclass=ABCMeta):
             ready_component = ready_task.target_component
             for workplace in ready_task.allocated_workplace_list:
                 if workplace.ID in target_workplace_id_list:
-                    if workplace.input_workplace_list != []:
-                        if (
-                            ready_component.placed_workplace != None
-                            and ready_component.placed_workplace != workplace
-                            and ready_component.placed_workplace not in workplace.input_workplace_list
-                        ):
-                            continue
-                        flag = False
-                        for ready_child_component in ready_component.child_component_list:
-                            if (
-                                ready_child_component.placed_workplace != None
-                                and ready_child_component.placed_workplace.output_workplace_list != []
-                                and ready_child_component.placed_workplace != workplace
-                                and ready_child_component.placed_workplace not in workplace.input_workplace_list
-                            ):
-                                flag = True
-                                break
-                        if flag:
-                            continue
+                    #"""
+
+                    #"""
                     if (
                         workplace.can_put(ready_component)
                         and workplace.get_total_workamount_skill(ready_task.name)

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -614,7 +614,7 @@ class BaseProject(object, metaclass=ABCMeta):
                 if workplace.ID in target_workplace_id_list:
                     if workplace.input_workplace_list != []:                        
                         if not(
-                            ready_component.placed_workplace == None
+                            ready_component.placed_workplace is None
                             or ready_component.placed_workplace == workplace
                             or ready_component.placed_workplace in workplace.input_workplace_list
                         ):
@@ -622,7 +622,7 @@ class BaseProject(object, metaclass=ABCMeta):
                         cannnot_set_ready_child_component_to_workplace = False
                         for ready_child_component in ready_component.child_component_list:
                             if not (
-                                ready_child_component.placed_workplace == None
+                                ready_child_component.placed_workplace is None
                                 or ready_child_component.placed_workplace.output_workplace_list == []
                                 or ready_child_component.placed_workplace == workplace
                                 or ready_child_component.placed_workplace in workplace.input_workplace_list

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -517,6 +517,7 @@ def test_simple_write_json(dummy_project):
     if os.path.exists("test2.json"):
         os.remove("test2.json")
 
+
 @pytest.fixture
 def dummy_conveyor_project():
     c1 = BaseComponent("c1")
@@ -528,7 +529,6 @@ def dummy_conveyor_project():
     taskB1 = BaseTask("B1", need_facility=True, default_work_amount=3)
     taskB2 = BaseTask("B2", need_facility=True, default_work_amount=5)
     taskB3 = BaseTask("B3", need_facility=True, default_work_amount=3)
-
 
     c1.extend_targeted_task_list([taskA1, taskB1])
     c2.extend_targeted_task_list([taskA2, taskB2])
@@ -575,14 +575,14 @@ def dummy_conveyor_project():
     wp4 = BaseWorkplace("workplace4", facility_list=[f4])
     wp4.extend_targeted_task_list([taskB1, taskB2, taskB3])
 
-    wp1.output_workplace_list=[wp3]
-    wp2.output_workplace_list=[wp4]
-    wp3.input_workplace_list=[wp1]
-    wp4.input_workplace_list=[wp2]
+    wp1.output_workplace_list = [wp3]
+    wp2.output_workplace_list = [wp4]
+    wp3.input_workplace_list = [wp1]
+    wp4.input_workplace_list = [wp2]
 
     # BaseTeams in BaseOrganization
     team = BaseTeam("team")
-    team_list= [team]
+    team_list = [team]
     team.extend_targeted_task_list([taskA1, taskA2, taskA3, taskB1, taskB2, taskB3])
 
     # BaseWorkers in each BaseTeam
@@ -592,7 +592,7 @@ def dummy_conveyor_project():
         taskA2.name: 1.0,
         taskA3.name: 1.0,
     }
-    w1.facility_skill_map = {f1.name: 1.0}  
+    w1.facility_skill_map = {f1.name: 1.0}
     team.worker_list.append(w1)
 
     w2 = BaseWorker("w2", team_id=team.ID)
@@ -600,8 +600,8 @@ def dummy_conveyor_project():
         taskA1.name: 1.0,
         taskA2.name: 1.0,
         taskA3.name: 1.0,
-    } 
-    w2.facility_skill_map = {f2.name: 1.0}  
+    }
+    w2.facility_skill_map = {f2.name: 1.0}
     team.worker_list.append(w2)
 
     w3 = BaseWorker("w3", team_id=team.ID)
@@ -609,8 +609,8 @@ def dummy_conveyor_project():
         taskB1.name: 1.0,
         taskB2.name: 1.0,
         taskB3.name: 1.0,
-    } 
-    w3.facility_skill_map = {f3.name: 1.0}  
+    }
+    w3.facility_skill_map = {f3.name: 1.0}
     team.worker_list.append(w3)
 
     w4 = BaseWorker("w4", team_id=team.ID)
@@ -618,47 +618,58 @@ def dummy_conveyor_project():
         taskB1.name: 1.0,
         taskB2.name: 1.0,
         taskB3.name: 1.0,
-    } 
-    w4.facility_skill_map = {f4.name: 1.0}  
+    }
+    w4.facility_skill_map = {f4.name: 1.0}
     team.worker_list.append(w4)
 
-    workplace_list=[wp1,wp2,wp3,wp4]
+    workplace_list = [wp1, wp2, wp3, wp4]
     # BaseProject including BaseProduct, BaseWorkflow and Organization
     project = BaseProject(
         init_datetime=datetime.datetime(2021, 7, 18, 8, 0, 0),
         unit_timedelta=datetime.timedelta(days=1),
         product=BaseProduct([c1, c2, c3]),
-        workflow=BaseWorkflow([taskA1, taskA2, taskA3,taskB1, taskB2, taskB3]),
+        workflow=BaseWorkflow([taskA1, taskA2, taskA3, taskB1, taskB2, taskB3]),
         organization=BaseOrganization(team_list, workplace_list),
     )
     return project
+
+
 def test_component_place_check_1(dummy_conveyor_project):
     dummy_conveyor_project.simulate(
         max_time=100,
         weekend_working=False,
     )
-    component_wp1_list=[]
-    for l in dummy_conveyor_project.organization.workplace_list[0].placed_component_id_record:
+    component_wp1_list = []
+    for l in dummy_conveyor_project.organization.workplace_list[
+        0
+    ].placed_component_id_record:
         for i in l:
             component_wp1_list.append(i)
 
-    component_wp2_list=[]
-    for l in dummy_conveyor_project.organization.workplace_list[1].placed_component_id_record:
+    component_wp2_list = []
+    for l in dummy_conveyor_project.organization.workplace_list[
+        1
+    ].placed_component_id_record:
         for i in l:
             component_wp2_list.append(i)
 
-    component_wp3_list=[]
-    for l in dummy_conveyor_project.organization.workplace_list[2].placed_component_id_record:
+    component_wp3_list = []
+    for l in dummy_conveyor_project.organization.workplace_list[
+        2
+    ].placed_component_id_record:
         for i in l:
             component_wp3_list.append(i)
 
-    component_wp4_list=[]
-    for l in dummy_conveyor_project.organization.workplace_list[3].placed_component_id_record:
+    component_wp4_list = []
+    for l in dummy_conveyor_project.organization.workplace_list[
+        3
+    ].placed_component_id_record:
         for i in l:
             component_wp4_list.append(i)
-    
-    assert set(component_wp1_list)== set(component_wp3_list)
-    assert set(component_wp2_list)== set(component_wp4_list)
+
+    assert set(component_wp1_list) == set(component_wp3_list)
+    assert set(component_wp2_list) == set(component_wp4_list)
+
 
 @pytest.fixture
 def dummy_conveyor_project_with_child_component():
@@ -728,14 +739,14 @@ def dummy_conveyor_project_with_child_component():
     wp4 = BaseWorkplace("workplace4", facility_list=[f4], max_space_size=4.0)
     wp4.extend_targeted_task_list([taskB1, taskB2, taskB3])
 
-    wp1.output_workplace_list=[wp3]
-    wp2.output_workplace_list=[wp4]
-    wp3.input_workplace_list=[wp1]
-    wp4.input_workplace_list=[wp2]
+    wp1.output_workplace_list = [wp3]
+    wp2.output_workplace_list = [wp4]
+    wp3.input_workplace_list = [wp1]
+    wp4.input_workplace_list = [wp2]
 
     # BaseTeams in BaseOrganization
     team = BaseTeam("team")
-    team_list= [team]
+    team_list = [team]
     team.extend_targeted_task_list([taskA1, taskA2, taskA3, taskB1, taskB2, taskB3])
 
     # BaseWorkers in each BaseTeam
@@ -745,7 +756,7 @@ def dummy_conveyor_project_with_child_component():
         taskA2.name: 1.0,
         taskA3.name: 1.0,
     }
-    w1.facility_skill_map = {f1.name: 1.0}  
+    w1.facility_skill_map = {f1.name: 1.0}
     team.worker_list.append(w1)
 
     w2 = BaseWorker("w2", team_id=team.ID)
@@ -753,8 +764,8 @@ def dummy_conveyor_project_with_child_component():
         taskA1.name: 1.0,
         taskA2.name: 1.0,
         taskA3.name: 1.0,
-    } 
-    w2.facility_skill_map = {f2.name: 1.0}  
+    }
+    w2.facility_skill_map = {f2.name: 1.0}
     team.worker_list.append(w2)
 
     w3 = BaseWorker("w3", team_id=team.ID)
@@ -762,8 +773,8 @@ def dummy_conveyor_project_with_child_component():
         taskB1.name: 1.0,
         taskB2.name: 1.0,
         taskB3.name: 1.0,
-    } 
-    w3.facility_skill_map = {f3.name: 1.0}  
+    }
+    w3.facility_skill_map = {f3.name: 1.0}
     team.worker_list.append(w3)
 
     w4 = BaseWorker("w4", team_id=team.ID)
@@ -771,44 +782,53 @@ def dummy_conveyor_project_with_child_component():
         taskB1.name: 1.0,
         taskB2.name: 1.0,
         taskB3.name: 1.0,
-    } 
-    w4.facility_skill_map = {f4.name: 1.0}  
+    }
+    w4.facility_skill_map = {f4.name: 1.0}
     team.worker_list.append(w4)
 
-    workplace_list=[wp1,wp2,wp3,wp4]
+    workplace_list = [wp1, wp2, wp3, wp4]
     # BaseProject including BaseProduct, BaseWorkflow and Organization
     project = BaseProject(
         init_datetime=datetime.datetime(2021, 8, 20, 8, 0, 0),
         unit_timedelta=datetime.timedelta(days=1),
         product=BaseProduct([c1_1, c1_2, c2_1, c2_2, c3_1, c3_2]),
-        workflow=BaseWorkflow([taskA1, taskA2, taskA3,taskB1, taskB2, taskB3]),
+        workflow=BaseWorkflow([taskA1, taskA2, taskA3, taskB1, taskB2, taskB3]),
         organization=BaseOrganization(team_list, workplace_list),
     )
     return project
+
+
 def test_component_place_check_2(dummy_conveyor_project_with_child_component):
     dummy_conveyor_project_with_child_component.simulate(
-        max_time=100,
-        weekend_working=False
+        max_time=100, weekend_working=False
     )
-    component_wp1_list=[]
-    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[0].placed_component_id_record:
+    component_wp1_list = []
+    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[
+        0
+    ].placed_component_id_record:
         for i in l:
             component_wp1_list.append(i)
 
-    component_wp2_list=[]
-    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[1].placed_component_id_record:
+    component_wp2_list = []
+    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[
+        1
+    ].placed_component_id_record:
         for i in l:
             component_wp2_list.append(i)
 
-    component_wp3_list=[]
-    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[2].placed_component_id_record:
+    component_wp3_list = []
+    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[
+        2
+    ].placed_component_id_record:
         for i in l:
             component_wp3_list.append(i)
 
-    component_wp4_list=[]
-    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[3].placed_component_id_record:
+    component_wp4_list = []
+    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[
+        3
+    ].placed_component_id_record:
         for i in l:
             component_wp4_list.append(i)
-    
-    assert set(component_wp1_list)<= set(component_wp3_list)
-    assert set(component_wp2_list)<= set(component_wp4_list)
+
+    assert set(component_wp1_list) <= set(component_wp3_list)
+    assert set(component_wp2_list) <= set(component_wp4_list)

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -522,12 +522,13 @@ def dummy_conveyor_project():
     c1 = BaseComponent("c1")
     c2 = BaseComponent("c2")
     c3 = BaseComponent("c3")
-    taskA1 = BaseTask("A1", need_facility=True, due_time=10)
-    taskA2 = BaseTask("A2", need_facility=True, due_time=5)
-    taskA3 = BaseTask("A3", need_facility=True, due_time=3)
-    taskB1 = BaseTask("B1", need_facility=True, due_time=3)
-    taskB2 = BaseTask("B2", need_facility=True, due_time=3)
-    taskB3 = BaseTask("B3", need_facility=True, due_time=3)
+    taskA1 = BaseTask("A1", need_facility=True, default_work_amount=10)
+    taskA2 = BaseTask("A2", need_facility=True, default_work_amount=3)
+    taskA3 = BaseTask("A3", need_facility=True, default_work_amount=3)
+    taskB1 = BaseTask("B1", need_facility=True, default_work_amount=3)
+    taskB2 = BaseTask("B2", need_facility=True, default_work_amount=5)
+    taskB3 = BaseTask("B3", need_facility=True, default_work_amount=3)
+
 
     c1.extend_targeted_task_list([taskA1, taskB1])
     c2.extend_targeted_task_list([taskA2, taskB2])
@@ -638,23 +639,27 @@ def test_component_place_check_1(dummy_conveyor_project):
     )
     component_wp1_list=[]
     for l in dummy_conveyor_project.organization.workplace_list[0].placed_component_id_record:
-        if len(l)== 1:
-            component_wp1_list.append(l[0])
+        for i in l:
+        #if len(l)== 1:
+            component_wp1_list.append(i)#l[0])
 
     component_wp2_list=[]
     for l in dummy_conveyor_project.organization.workplace_list[1].placed_component_id_record:
-        if len(l)== 1:
-            component_wp2_list.append(l[0])
+        for i in l:
+        #if len(l)== 1:
+            component_wp2_list.append(i)#l[0])
 
     component_wp3_list=[]
     for l in dummy_conveyor_project.organization.workplace_list[2].placed_component_id_record:
-        if len(l)== 1:
-            component_wp3_list.append(l[0])
+        for i in l:
+        #if len(l)== 1:
+            component_wp3_list.append(i)#l[0])
 
     component_wp4_list=[]
     for l in dummy_conveyor_project.organization.workplace_list[3].placed_component_id_record:
-        if len(l)== 1:
-            component_wp4_list.append(l[0])
+        for i in l:
+        #if len(l)== 1:
+            component_wp4_list.append(i)#l[0])
     
     assert set(component_wp1_list)== set(component_wp3_list)
     assert set(component_wp2_list)== set(component_wp4_list)
@@ -672,12 +677,12 @@ def dummy_conveyor_project_with_child_component():
     c2_2.append_child_component(c2_1)
     c3_2.append_child_component(c3_1)
 
-    taskA1 = BaseTask("A1", need_facility=True, due_time=10)
-    taskA2 = BaseTask("A2", need_facility=True, due_time=5)
-    taskA3 = BaseTask("A3", need_facility=True, due_time=3)
-    taskB1 = BaseTask("B1", need_facility=True, due_time=3)
-    taskB2 = BaseTask("B2", need_facility=True, due_time=3)
-    taskB3 = BaseTask("B3", need_facility=True, due_time=3)
+    taskA1 = BaseTask("A1", need_facility=True, default_work_amount=10)
+    taskA2 = BaseTask("A2", need_facility=True, default_work_amount=3)
+    taskA3 = BaseTask("A3", need_facility=True, default_work_amount=3)
+    taskB1 = BaseTask("B1", need_facility=True, default_work_amount=3)
+    taskB2 = BaseTask("B2", need_facility=True, default_work_amount=3)
+    taskB3 = BaseTask("B3", need_facility=True, default_work_amount=5)
 
     c1_1.append_targeted_task(taskA1)
     c1_2.append_targeted_task(taskB1)
@@ -718,9 +723,9 @@ def dummy_conveyor_project_with_child_component():
     }
 
     # Workplace in BaseOrganization
-    wp1 = BaseWorkplace("workplace1", facility_list=[f1], max_space_size=4.0)
+    wp1 = BaseWorkplace("workplace1", facility_list=[f1], max_space_size=1.0)
     wp1.extend_targeted_task_list([taskA1, taskA2, taskA3])
-    wp2 = BaseWorkplace("workplace2", facility_list=[f2], max_space_size=4.0)
+    wp2 = BaseWorkplace("workplace2", facility_list=[f2], max_space_size=2.0)
     wp2.extend_targeted_task_list([taskA1, taskA2, taskA3])
     wp3 = BaseWorkplace("workplace3", facility_list=[f3], max_space_size=4.0)
     wp3.extend_targeted_task_list([taskB1, taskB2, taskB3])
@@ -791,23 +796,27 @@ def test_component_place_check_2(dummy_conveyor_project_with_child_component):
     )
     component_wp1_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[0].placed_component_id_record:
-        if len(l)==1:
-            component_wp1_list.append(l[0])
+        for i in l:
+        #if len(l)==1:
+            component_wp1_list.append(i)#l[0])
 
     component_wp2_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[1].placed_component_id_record:
-        if len(l)==1:
-            component_wp2_list.append(l[0])
+        for i in l:
+        #if len(l)==1:
+            component_wp2_list.append(i)#l[0])
 
     component_wp3_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[2].placed_component_id_record:
-        if len(l)==1:
-            component_wp3_list.append(l[0])
+        for i in l:
+        #if len(l)==1:
+            component_wp3_list.append(i)#l[0])
 
     component_wp4_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[3].placed_component_id_record:
-        if len(l)==1:
-            component_wp4_list.append(l[0])
+        for i in l:
+        #if len(l)==1:
+            component_wp4_list.append(i)#l[0])
     
     assert set(component_wp1_list)<= set(component_wp3_list)
     assert set(component_wp2_list)<= set(component_wp4_list)

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -792,22 +792,22 @@ def test_component_place_check_2(dummy_conveyor_project_with_child_component):
     component_wp1_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[0].placed_component_id_record:
         if len(l)==1:
-            component_wp1_list.append(l)
+            component_wp1_list.append(l[0])
 
     component_wp2_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[1].placed_component_id_record:
         if len(l)==1:
-            component_wp2_list.append(l)
+            component_wp2_list.append(l[0])
 
     component_wp3_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[2].placed_component_id_record:
         if len(l)==1:
-            component_wp3_list.append(l)
+            component_wp3_list.append(l[0])
 
     component_wp4_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[3].placed_component_id_record:
         if len(l)==1:
-            component_wp4_list.append(l)
+            component_wp4_list.append(l[0])
     
     assert set(component_wp1_list)<= set(component_wp3_list)
     assert set(component_wp2_list)<= set(component_wp4_list)

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -45,7 +45,6 @@ def dummy_project(scope="function"):
     f1.workamount_skill_mean_map = {
         task1_1.name: 1.0,
     }
-    # workplace.facility_list.append(f1)
 
     # Workplace in BaseOrganization
     workplace = BaseWorkplace("workplace", facility_list=[f1])
@@ -64,7 +63,7 @@ def dummy_project(scope="function"):
         task3.name: 1.0,
     }
     w1.facility_skill_map = {f1.name: 1.0}
-    team.worker_list.append(w1)
+    team.add_worker(w1)
 
     w2 = BaseWorker("w2", team_id=team.ID, cost_per_time=6.0)
     w2.workamount_skill_mean_map = {
@@ -74,7 +73,7 @@ def dummy_project(scope="function"):
         task3.name: 1.0,
     }
     w2.facility_skill_map = {f1.name: 1.0}
-    team.worker_list.append(w2)
+    team.add_worker(w2)
 
     # BaseProject including BaseProduct, BaseWorkflow and Organization
     project = BaseProject(
@@ -119,7 +118,6 @@ def dummy_project2(scope="function"):
     f1.workamount_skill_mean_map = {
         task1_1.name: 1.0,
     }
-    # workplace.facility_list.append(f1)
 
     # Workplace in BaseOrganization
     workplace = BaseWorkplace("workplace", facility_list=[f1])
@@ -138,7 +136,7 @@ def dummy_project2(scope="function"):
         task3.name: 1.0,
     }
     w1.facility_skill_map = {f1.name: 1.0}
-    team.worker_list.append(w1)
+    team.add_worker(w1)
 
     w2 = BaseWorker("w2", team_id=team.ID, cost_per_time=6.0)
     w2.solo_working = True
@@ -149,7 +147,7 @@ def dummy_project2(scope="function"):
         task3.name: 1.0,
     }
     w2.facility_skill_map = {f1.name: 1.0}
-    team.worker_list.append(w2)
+    team.add_worker(w2)
 
     # BaseProject including BaseProduct, BaseWorkflow and Organization
     project = BaseProject(
@@ -213,7 +211,7 @@ def dummy_place_check():
         task3.name: 1.0,
     }
     w1.facility_skill_map = {f1.name: 1.0}
-    team.worker_list.append(w1)
+    team.add_worker(w1)
 
     w2 = BaseWorker("w2", team_id=team.ID, cost_per_time=6.0)
     w2.workamount_skill_mean_map = {
@@ -222,7 +220,7 @@ def dummy_place_check():
         task3.name: 1.0,
     }
     w2.facility_skill_map = {f2.name: 1.0}
-    team.worker_list.append(w2)
+    team.add_worker(w2)
 
     # BaseProject including BaseProduct, BaseWorkflow and Organization
     project = BaseProject(
@@ -575,10 +573,8 @@ def dummy_conveyor_project():
     wp4 = BaseWorkplace("workplace4", facility_list=[f4])
     wp4.extend_targeted_task_list([taskB1, taskB2, taskB3])
 
-    wp1.output_workplace_list = [wp3]
-    wp2.output_workplace_list = [wp4]
-    wp3.input_workplace_list = [wp1]
-    wp4.input_workplace_list = [wp2]
+    wp3.append_input_workplace(wp1)
+    wp4.append_input_workplace(wp2)
 
     # BaseTeams in BaseOrganization
     team = BaseTeam("team")
@@ -593,7 +589,7 @@ def dummy_conveyor_project():
         taskA3.name: 1.0,
     }
     w1.facility_skill_map = {f1.name: 1.0}
-    team.worker_list.append(w1)
+    team.add_worker(w1)
 
     w2 = BaseWorker("w2", team_id=team.ID)
     w2.workamount_skill_mean_map = {
@@ -602,7 +598,7 @@ def dummy_conveyor_project():
         taskA3.name: 1.0,
     }
     w2.facility_skill_map = {f2.name: 1.0}
-    team.worker_list.append(w2)
+    team.add_worker(w2)
 
     w3 = BaseWorker("w3", team_id=team.ID)
     w3.workamount_skill_mean_map = {
@@ -611,7 +607,7 @@ def dummy_conveyor_project():
         taskB3.name: 1.0,
     }
     w3.facility_skill_map = {f3.name: 1.0}
-    team.worker_list.append(w3)
+    team.add_worker(w3)
 
     w4 = BaseWorker("w4", team_id=team.ID)
     w4.workamount_skill_mean_map = {
@@ -620,7 +616,7 @@ def dummy_conveyor_project():
         taskB3.name: 1.0,
     }
     w4.facility_skill_map = {f4.name: 1.0}
-    team.worker_list.append(w4)
+    team.add_worker(w4)
 
     workplace_list = [wp1, wp2, wp3, wp4]
     # BaseProject including BaseProduct, BaseWorkflow and Organization
@@ -739,10 +735,8 @@ def dummy_conveyor_project_with_child_component():
     wp4 = BaseWorkplace("workplace4", facility_list=[f4], max_space_size=4.0)
     wp4.extend_targeted_task_list([taskB1, taskB2, taskB3])
 
-    wp1.output_workplace_list = [wp3]
-    wp2.output_workplace_list = [wp4]
-    wp3.input_workplace_list = [wp1]
-    wp4.input_workplace_list = [wp2]
+    wp3.append_input_workplace(wp1)
+    wp4.append_input_workplace(wp2)
 
     # BaseTeams in BaseOrganization
     team = BaseTeam("team")
@@ -757,7 +751,7 @@ def dummy_conveyor_project_with_child_component():
         taskA3.name: 1.0,
     }
     w1.facility_skill_map = {f1.name: 1.0}
-    team.worker_list.append(w1)
+    team.add_worker(w1)
 
     w2 = BaseWorker("w2", team_id=team.ID)
     w2.workamount_skill_mean_map = {
@@ -766,7 +760,7 @@ def dummy_conveyor_project_with_child_component():
         taskA3.name: 1.0,
     }
     w2.facility_skill_map = {f2.name: 1.0}
-    team.worker_list.append(w2)
+    team.add_worker(w2)
 
     w3 = BaseWorker("w3", team_id=team.ID)
     w3.workamount_skill_mean_map = {
@@ -775,7 +769,7 @@ def dummy_conveyor_project_with_child_component():
         taskB3.name: 1.0,
     }
     w3.facility_skill_map = {f3.name: 1.0}
-    team.worker_list.append(w3)
+    team.add_worker(w3)
 
     w4 = BaseWorker("w4", team_id=team.ID)
     w4.workamount_skill_mean_map = {
@@ -784,7 +778,7 @@ def dummy_conveyor_project_with_child_component():
         taskB3.name: 1.0,
     }
     w4.facility_skill_map = {f4.name: 1.0}
-    team.worker_list.append(w4)
+    team.add_worker(w4)
 
     workplace_list = [wp1, wp2, wp3, wp4]
     # BaseProject including BaseProduct, BaseWorkflow and Organization

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -640,26 +640,22 @@ def test_component_place_check_1(dummy_conveyor_project):
     component_wp1_list=[]
     for l in dummy_conveyor_project.organization.workplace_list[0].placed_component_id_record:
         for i in l:
-        #if len(l)== 1:
-            component_wp1_list.append(i)#l[0])
+            component_wp1_list.append(i)
 
     component_wp2_list=[]
     for l in dummy_conveyor_project.organization.workplace_list[1].placed_component_id_record:
         for i in l:
-        #if len(l)== 1:
-            component_wp2_list.append(i)#l[0])
+            component_wp2_list.append(i)
 
     component_wp3_list=[]
     for l in dummy_conveyor_project.organization.workplace_list[2].placed_component_id_record:
         for i in l:
-        #if len(l)== 1:
-            component_wp3_list.append(i)#l[0])
+            component_wp3_list.append(i)
 
     component_wp4_list=[]
     for l in dummy_conveyor_project.organization.workplace_list[3].placed_component_id_record:
         for i in l:
-        #if len(l)== 1:
-            component_wp4_list.append(i)#l[0])
+            component_wp4_list.append(i)
     
     assert set(component_wp1_list)== set(component_wp3_list)
     assert set(component_wp2_list)== set(component_wp4_list)
@@ -797,26 +793,22 @@ def test_component_place_check_2(dummy_conveyor_project_with_child_component):
     component_wp1_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[0].placed_component_id_record:
         for i in l:
-        #if len(l)==1:
-            component_wp1_list.append(i)#l[0])
+            component_wp1_list.append(i)
 
     component_wp2_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[1].placed_component_id_record:
         for i in l:
-        #if len(l)==1:
-            component_wp2_list.append(i)#l[0])
+            component_wp2_list.append(i)
 
     component_wp3_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[2].placed_component_id_record:
         for i in l:
-        #if len(l)==1:
-            component_wp3_list.append(i)#l[0])
+            component_wp3_list.append(i)
 
     component_wp4_list=[]
     for l in dummy_conveyor_project_with_child_component.organization.workplace_list[3].placed_component_id_record:
         for i in l:
-        #if len(l)==1:
-            component_wp4_list.append(i)#l[0])
+            component_wp4_list.append(i)
     
     assert set(component_wp1_list)<= set(component_wp3_list)
     assert set(component_wp2_list)<= set(component_wp4_list)

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -572,14 +572,14 @@ def dummy_conveyor_project():
     wp3 = BaseWorkplace("workplace3", facility_list=[f3])
     wp3.extend_targeted_task_list([taskB1, taskB2, taskB3])
     wp4 = BaseWorkplace("workplace4", facility_list=[f4])
-    wp4.extend_targeted_task_list([taskB1, taskB2, taskB3]) 
+    wp4.extend_targeted_task_list([taskB1, taskB2, taskB3])
 
-    wp1.output_workplace_list([wp3])
-    wp2.output_workplace_list([wp4])
-    wp3.input_workplace_list([wp1])
-    wp4.input_workplace_list([wp2])
+    wp1.output_workplace_list=[wp3]
+    wp2.output_workplace_list=[wp4]
+    wp3.input_workplace_list=[wp1]
+    wp4.input_workplace_list=[wp2]
 
-  # BaseTeams in BaseOrganization
+    # BaseTeams in BaseOrganization
     team = BaseTeam("team")
     team_list= [team]
     team.extend_targeted_task_list([taskA1, taskA2, taskA3, taskB1, taskB2, taskB3])
@@ -654,7 +654,7 @@ def test_component_place_check(dummy_conveyor_project):
     component_wp4_list=[]
     for l in dummy_conveyor_project.organization.workplace_list[3].placed_component_id_record:
         if len(l)== 1:
-            component_wp1_list.append(l[0])
+            component_wp4_list.append(l[0])
     
     assert set(component_wp1_list)== set(component_wp3_list)
     assert set(component_wp2_list)== set(component_wp4_list)

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -631,7 +631,7 @@ def dummy_conveyor_project():
         organization=BaseOrganization(team_list, workplace_list),
     )
     return project
-def test_component_place_check(dummy_conveyor_project):
+def test_component_place_check_1(dummy_conveyor_project):
     dummy_conveyor_project.simulate(
         max_time=100,
         weekend_working=False,
@@ -658,3 +658,156 @@ def test_component_place_check(dummy_conveyor_project):
     
     assert set(component_wp1_list)== set(component_wp3_list)
     assert set(component_wp2_list)== set(component_wp4_list)
+
+@pytest.fixture
+def dummy_conveyor_project_with_child_component():
+    c1_1 = BaseComponent("c1_1")
+    c1_2 = BaseComponent("c1_2")
+    c2_1 = BaseComponent("c2_1")
+    c2_2 = BaseComponent("c2_2")
+    c3_1 = BaseComponent("c3_1")
+    c3_2 = BaseComponent("c3_2")
+
+    c1_2.append_child_component(c1_1)
+    c2_2.append_child_component(c2_1)
+    c3_2.append_child_component(c3_1)
+
+    taskA1 = BaseTask("A1", need_facility=True, due_time=10)
+    taskA2 = BaseTask("A2", need_facility=True, due_time=5)
+    taskA3 = BaseTask("A3", need_facility=True, due_time=3)
+    taskB1 = BaseTask("B1", need_facility=True, due_time=3)
+    taskB2 = BaseTask("B2", need_facility=True, due_time=3)
+    taskB3 = BaseTask("B3", need_facility=True, due_time=3)
+
+    c1_1.append_targeted_task(taskA1)
+    c1_2.append_targeted_task(taskB1)
+    c2_1.append_targeted_task(taskA2)
+    c2_2.append_targeted_task(taskB2)
+    c3_1.append_targeted_task(taskA3)
+    c3_2.append_targeted_task(taskB3)
+
+    taskB1.append_input_task(taskA1)
+    taskB2.append_input_task(taskA2)
+    taskB3.append_input_task(taskA3)
+
+    f1 = BaseFacility("f1")
+    f1.workamount_skill_mean_map = {
+        taskA1.name: 1.0,
+        taskA2.name: 1.0,
+        taskA3.name: 1.0,
+    }
+
+    f2 = BaseFacility("f2")
+    f2.workamount_skill_mean_map = {
+        taskA1.name: 1.0,
+        taskA2.name: 1.0,
+        taskA3.name: 1.0,
+    }
+
+    f3 = BaseFacility("f3")
+    f3.workamount_skill_mean_map = {
+        taskB1.name: 1.0,
+        taskB2.name: 1.0,
+        taskB3.name: 1.0,
+    }
+    f4 = BaseFacility("f4")
+    f4.workamount_skill_mean_map = {
+        taskB1.name: 1.0,
+        taskB2.name: 1.0,
+        taskB3.name: 1.0,
+    }
+
+    # Workplace in BaseOrganization
+    wp1 = BaseWorkplace("workplace1", facility_list=[f1], max_space_size=4.0)
+    wp1.extend_targeted_task_list([taskA1, taskA2, taskA3])
+    wp2 = BaseWorkplace("workplace2", facility_list=[f2], max_space_size=4.0)
+    wp2.extend_targeted_task_list([taskA1, taskA2, taskA3])
+    wp3 = BaseWorkplace("workplace3", facility_list=[f3], max_space_size=4.0)
+    wp3.extend_targeted_task_list([taskB1, taskB2, taskB3])
+    wp4 = BaseWorkplace("workplace4", facility_list=[f4], max_space_size=4.0)
+    wp4.extend_targeted_task_list([taskB1, taskB2, taskB3])
+
+    wp1.output_workplace_list=[wp3]
+    wp2.output_workplace_list=[wp4]
+    wp3.input_workplace_list=[wp1]
+    wp4.input_workplace_list=[wp2]
+
+    # BaseTeams in BaseOrganization
+    team = BaseTeam("team")
+    team_list= [team]
+    team.extend_targeted_task_list([taskA1, taskA2, taskA3, taskB1, taskB2, taskB3])
+
+    # BaseWorkers in each BaseTeam
+    w1 = BaseWorker("w1", team_id=team.ID)
+    w1.workamount_skill_mean_map = {
+        taskA1.name: 1.0,
+        taskA2.name: 1.0,
+        taskA3.name: 1.0,
+    }
+    w1.facility_skill_map = {f1.name: 1.0}  
+    team.worker_list.append(w1)
+
+    w2 = BaseWorker("w2", team_id=team.ID)
+    w2.workamount_skill_mean_map = {
+        taskA1.name: 1.0,
+        taskA2.name: 1.0,
+        taskA3.name: 1.0,
+    } 
+    w2.facility_skill_map = {f2.name: 1.0}  
+    team.worker_list.append(w2)
+
+    w3 = BaseWorker("w3", team_id=team.ID)
+    w3.workamount_skill_mean_map = {
+        taskB1.name: 1.0,
+        taskB2.name: 1.0,
+        taskB3.name: 1.0,
+    } 
+    w3.facility_skill_map = {f3.name: 1.0}  
+    team.worker_list.append(w3)
+
+    w4 = BaseWorker("w4", team_id=team.ID)
+    w4.workamount_skill_mean_map = {
+        taskB1.name: 1.0,
+        taskB2.name: 1.0,
+        taskB3.name: 1.0,
+    } 
+    w4.facility_skill_map = {f4.name: 1.0}  
+    team.worker_list.append(w4)
+
+    workplace_list=[wp1,wp2,wp3,wp4]
+    # BaseProject including BaseProduct, BaseWorkflow and Organization
+    project = BaseProject(
+        init_datetime=datetime.datetime(2021, 8, 20, 8, 0, 0),
+        unit_timedelta=datetime.timedelta(days=1),
+        product=BaseProduct([c1_1, c1_2, c2_1, c2_2, c3_1, c3_2]),
+        workflow=BaseWorkflow([taskA1, taskA2, taskA3,taskB1, taskB2, taskB3]),
+        organization=BaseOrganization(team_list, workplace_list),
+    )
+    return project
+def test_component_place_check_2(dummy_conveyor_project_with_child_component):
+    dummy_conveyor_project_with_child_component.simulate(
+        max_time=100,
+        weekend_working=False
+    )
+    component_wp1_list=[]
+    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[0].placed_component_id_record:
+        if len(l)==1:
+            component_wp1_list.append(l)
+
+    component_wp2_list=[]
+    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[1].placed_component_id_record:
+        if len(l)==1:
+            component_wp2_list.append(l)
+
+    component_wp3_list=[]
+    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[2].placed_component_id_record:
+        if len(l)==1:
+            component_wp3_list.append(l)
+
+    component_wp4_list=[]
+    for l in dummy_conveyor_project_with_child_component.organization.workplace_list[3].placed_component_id_record:
+        if len(l)==1:
+            component_wp4_list.append(l)
+    
+    assert set(component_wp1_list)<= set(component_wp3_list)
+    assert set(component_wp2_list)<= set(component_wp4_list)


### PR DESCRIPTION
I added constraints considering the input and output of workplace on __allocate_component_to_workplace in bese_project.py. I checked that no error occurs in pytest.

It seems that there is no case of considering child components in the test, is it OK?