### PR TITLE
just comment out some lines in get_time_list_for_gannt_chart.

### DIFF
--- a/pDESy/model/base_component.py
+++ b/pDESy/model/base_component.py
@@ -442,12 +442,11 @@ class BaseComponent(object, metaclass=abc.ABCMeta):
                             )
                     from_time = time
                     to_time = -1
+                # if previous_state == BaseComponentState.WORKING:
+                #    working_time_list.append((from_time, time - from_time + finish_margin))
+                # elif previous_state == BaseComponentState.READY:
+                #    ready_time_list.append((from_time, time - from_time + finish_margin))
             previous_state = state
-
-            if previous_state == BaseComponentState.WORKING:
-                working_time_list.append((from_time, time - from_time + finish_margin))
-            elif previous_state == BaseComponentState.READY:
-                ready_time_list.append((from_time, time - from_time + finish_margin))
         return ready_time_list, working_time_list
 
     def create_data_for_gantt_plotly(

--- a/pDESy/model/base_resource.py
+++ b/pDESy/model/base_resource.py
@@ -264,12 +264,12 @@ class BaseResource(object, metaclass=abc.ABCMeta):
                     to_time = -1
             previous_state = state
 
-            if previous_state == BaseResourceState.WORKING:
-                working_time_list.append((from_time, time - from_time + finish_margin))
-            elif previous_state == BaseResourceState.FREE:
-                ready_time_list.append(
-                    (from_time, time - 1 - from_time + finish_margin)
-                )
+            # if previous_state == BaseResourceState.WORKING:
+            #    working_time_list.append((from_time, time - from_time + finish_margin))
+            # elif previous_state == BaseResourceState.FREE:
+            #    ready_time_list.append(
+            #        (from_time, time - 1 - from_time + finish_margin)
+            #    )
         return ready_time_list, working_time_list
 
     def has_workamount_skill(self, task_name, error_tol=1e-10):

--- a/pDESy/model/base_task.py
+++ b/pDESy/model/base_task.py
@@ -653,10 +653,10 @@ class BaseTask(object, metaclass=abc.ABCMeta):
                     to_time = -1
             previous_state = state
 
-            if previous_state == BaseTaskState.WORKING:
-                working_time_list.append((from_time, time - from_time + finish_margin))
-            elif previous_state == BaseTaskState.READY:
-                ready_time_list.append((from_time, time - from_time + finish_margin))
+            # if previous_state == BaseTaskState.WORKING:
+            #    working_time_list.append((from_time, time - from_time + finish_margin))
+            # elif previous_state == BaseTaskState.READY:
+            #    ready_time_list.append((from_time, time - from_time + finish_margin))
         return ready_time_list, working_time_list
 
     def create_data_for_gantt_plotly(


### PR DESCRIPTION
各モデルのget_time_list_for_gantt_chartの一部をコメントアウトしました。
[working, working, working, Finished, Finished]　をstate_recordとして持つ場合、
working_time_listとして
[(0, 1.0), (0, 2.0), (0, 3.0)] を返すような実装になっていたので、
[(0, 3.0)]を返すように変更。
結果、数行をコメントアウトするだけで実現できたので、そのように修正。

ただ、この行、わざと後から追加されているように見えるので、他に影響が出る恐れあり。