### PR TITLE
Remove minus time from absence_time_list

### DIFF
--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -508,9 +508,12 @@ class BaseProject(object, metaclass=ABCMeta):
         total_step_length = len(self.log_txt)
         self.absence_time_list = sorted(
             list(
-                map(
-                    lambda abs_time: total_step_length - abs_time - 1,
-                    self.absence_time_list,
+                filter(
+                    lambda abs_time: abs_time >= 0,
+                    map(
+                        lambda abs_time: total_step_length - abs_time - 1,
+                        self.absence_time_list,
+                    ),
                 )
             )
         )


### PR DESCRIPTION
The following bugs were addressed by automatically removing the negative absence time.

```py
absence_time_list=[2,3,5,25]
project.backward_simulate(max_time = 200, print_debug=True,absence_time_list=absence_time_list) # simulation considering absence_time_list
print(project.absence_time_list) # out: [-17, 3, 5, 6]
project.remove_absence_time_list()  # ERROR because absence_time_list has negative step time
```