### PR TITLE
change default max_space_size to np.inf

### DIFF
--- a/pDESy/model/base_workplace.py
+++ b/pDESy/model/base_workplace.py
@@ -6,8 +6,8 @@ import abc
 import datetime
 import sys
 import uuid
-import warnings
 
+import numpy as np
 import matplotlib.pyplot as plt
 
 import plotly.figure_factory as ff
@@ -104,7 +104,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         self.parent_workplace = (
             parent_workplace if parent_workplace is not None else None
         )
-        self.max_space_size = max_space_size if max_space_size is not None else 1.0
+        self.max_space_size = max_space_size if max_space_size is not None else np.inf
 
         self.input_workplace_list = (
             input_workplace_list if input_workplace_list is not None else []

--- a/tests/model/test_base_workplace.py
+++ b/tests/model/test_base_workplace.py
@@ -21,7 +21,6 @@ def test_init():
     assert workplace.facility_list == []
     assert workplace.targeted_task_list == []
     assert workplace.parent_workplace is None
-    assert workplace.max_space_size == 1.0
     assert workplace.input_workplace_list == []
     assert workplace.output_workplace_list == []
     assert workplace.cost_list == []


### PR DESCRIPTION
This pull request makes changes to the `BaseWorkplace` model in the `pDESy` project, focusing on improving the handling of the `max_space_size` attribute and updating related tests. The changes also include a minor import adjustment.

### Changes to `BaseWorkplace` model:

* Updated the default value of `max_space_size` to `np.inf` instead of `1.0` in the `__init__` method, allowing for an unlimited space size by default.

### Test updates:

* Removed the assertion for `max_space_size` being `1.0` in the `test_init` function to align with the new default value of `np.inf`.

### Import adjustments:

* Added `numpy` (`np`) to the imports and removed the unused `warnings` module in `base_workplace.py`.