### PR TITLE
Change default subgraph to True

### DIFF
--- a/pDESy/model/base_team.py
+++ b/pDESy/model/base_team.py
@@ -1051,7 +1051,7 @@ class BaseTeam(object, metaclass=abc.ABCMeta):
         print_worker: bool = True,
         shape_worker: str = "stadium",
         link_type_str: str = "-->",
-        subgraph: bool = False,
+        subgraph: bool = True,
         subgraph_direction: str = "LR",
     ):
         """
@@ -1096,7 +1096,7 @@ class BaseTeam(object, metaclass=abc.ABCMeta):
         print_worker: bool = True,
         shape_worker: str = "stadium",
         link_type_str: str = "-->",
-        subgraph: bool = False,
+        subgraph: bool = True,
         subgraph_direction: str = "LR",
     ):
         """


### PR DESCRIPTION
This pull request updates the default behavior for generating Mermaid diagrams in the `pDESy/model/base_team.py` file. The changes ensure that subgraphs are enabled by default in two key methods.

Changes to default subgraph behavior:

* [`print_target_worker_mermaid_diagram`](diffhunk://#diff-b67334e4fdae4a11a40ebb313f4712fd94301ea0f27a890a98c9fc6905906a85L1054-R1054): The `subgraph` parameter's default value was changed from `False` to `True`, enabling subgraph generation by default.
* [`print_mermaid_diagram`](diffhunk://#diff-b67334e4fdae4a11a40ebb313f4712fd94301ea0f27a890a98c9fc6905906a85L1099-R1099): Similarly, the `subgraph` parameter's default value was updated from `False` to `True`, making subgraph generation the default behavior.