### PR TITLE
add mermaid link between each workplace

### DIFF
--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -2050,6 +2050,7 @@ class BaseProject(object, metaclass=ABCMeta):
         link_type_str_worker_task: str = "-.-",
         link_type_str_facility_task: str = "-.-",
         link_type_str_worker_facility: str = "-.-",
+        link_type_str_workplace_workplace: str = "-->",
         subgraph: bool = False,
         subgraph_direction: str = "LR",
     ):
@@ -2141,6 +2142,9 @@ class BaseProject(object, metaclass=ABCMeta):
             link_type_str_worker_facility (str, optional):
                 Link type string of each worker and facility.
                 Defaults to "-.-".
+            link_type_str_workplace_workplace (str, optional):
+                Link type string of each workplace and workplace.
+                Defaults to "-->".
             subgraph (bool, optional):
                 Subgraph or not.
                 Defaults to False.
@@ -2220,6 +2224,13 @@ class BaseProject(object, metaclass=ABCMeta):
                         list_of_lines.append(
                             f"{workplace.ID}{link_type_str_facility_task}{t.ID}"
                         )
+
+        # workplace -> workplace
+        for workplace in target_workplace_list:
+            for input_workplace in workplace.input_workplace_list:
+                list_of_lines.append(
+                    f"{input_workplace.ID}{link_type_str_workplace_workplace}{workplace.ID}"
+                )
 
         if subgraph:
             list_of_lines.append("end")

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -968,7 +968,7 @@ def test_subproject_task(dummy_project):
             os.remove(file_p)
 
 
-def test_print_mermaid_diagram(dummy_project_multiple):
+def test_print_mermaid_diagram(dummy_project_multiple, dummy_conveyor_project):
     """test_print_mermaid_diagram."""
     dummy_project_multiple.print_mermaid_diagram(orientations="LR", subgraph=True)
     dummy_project_multiple.print_target_mermaid_diagram(
@@ -978,6 +978,7 @@ def test_print_mermaid_diagram(dummy_project_multiple):
         orientations="TB",
         subgraph=False,
     )
+    dummy_conveyor_project.print_mermaid_diagram()
 
 
 def test_print_target_product_related_mermaid_diagram(dummy_project_multiple):


### PR DESCRIPTION
This pull request introduces enhancements to the `get_target_mermaid_diagram` function in `pDESy/model/base_project.py` to support workplace-to-workplace relationships in Mermaid diagrams. It also updates the corresponding test suite to ensure the new functionality is covered.

### Enhancements to `get_target_mermaid_diagram`:

* Added a new parameter `link_type_str_workplace_workplace` to specify the link type string for workplace-to-workplace relationships, with a default value of `"-->"`. [[1]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR2053) [[2]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR2145-R2147)
* Implemented logic to generate Mermaid diagram lines for workplace-to-workplace links using the new parameter.

### Updates to the test suite:

* Modified the `test_print_mermaid_diagram` function to include a new test case for `dummy_conveyor_project`, ensuring workplace-to-workplace links are correctly rendered in the Mermaid diagram. [[1]](diffhunk://#diff-9d7964630fe34043135004bf01fbb8d8dfbf6c1a11da850ce2fcc9f2619e4ab5L971-R971) [[2]](diffhunk://#diff-9d7964630fe34043135004bf01fbb8d8dfbf6c1a11da850ce2fcc9f2619e4ab5R981)