### PR TITLE
bugfix task mermaid

### DIFF
--- a/pDESy/model/base_task.py
+++ b/pDESy/model/base_task.py
@@ -960,7 +960,7 @@ class BaseTask(object, metaclass=abc.ABCMeta):
             list_of_lines.append(f"direction {subgraph_direction}")
         node_label = self.name
         if print_work_amount_info:
-            node_label += f"<br>{self.default_work_amount}/{self.remaining_work_amount}"
+            node_label += f"<br>{self.remaining_work_amount}"
         list_of_lines.append(f"{self.ID}@{{shape: {shape}, label: '{node_label}'}}")
 
         if subgraph:


### PR DESCRIPTION
This pull request includes a minor update to the `get_mermaid_diagram` method in the `pDESy/model/base_task.py` file. The change simplifies the node label by removing the display of `default_work_amount` and only showing `remaining_work_amount` in the diagram.