### PR TITLE
fix bug of workplace relationship

### DIFF
--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -4679,6 +4679,7 @@ class BaseProject(object, metaclass=ABCMeta):
         link_type_str_facility: str = "-->",
         subgraph: bool = True,
         subgraph_direction: str = "LR",
+        link_type_str_workplace_workplace: str = "-->",
     ):
         """
         Get mermaid diagram of all workplace.
@@ -4699,6 +4700,11 @@ class BaseProject(object, metaclass=ABCMeta):
             subgraph_direction (str, optional):
                 Direction of subgraph.
                 Defaults to "LR".
+            link_type_str_workplace_workplace (str, optional):
+                Link type string of each workplace.
+                Defaults to "-->".
+        Returns:
+            list[str]: List of lines for mermaid diagram.
         """
         list_of_lines = []
         for workplace in self.workplace_list:
@@ -4711,6 +4717,13 @@ class BaseProject(object, metaclass=ABCMeta):
                     subgraph_direction=subgraph_direction,
                 )
             )
+        # workplace -> workplace
+        for workplace in self.workplace_list:
+            for input_workplace in workplace.input_workplace_list:
+                list_of_lines.append(
+                    f"{input_workplace.ID}{link_type_str_workplace_workplace}{workplace.ID}"
+                )
+
         return list_of_lines
 
     def print_all_workplace_mermaid_diagram(


### PR DESCRIPTION
This pull request introduces enhancements to the `get_all_workplace_mermaid_diagram` method in `pDESy/model/base_project.py`. The changes add functionality to include workplace-to-workplace relationships in the generated mermaid diagram, improving its comprehensiveness.

### Enhancements to mermaid diagram generation:

* Added a new parameter, `link_type_str_workplace_workplace`, to specify the link type string for workplace-to-workplace relationships. This parameter has a default value of `"-->"`. [[1]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR4682) [[2]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR4703-R4707)
* Updated the docstring to document the new parameter and its purpose, along with the return type (`list[str]`) for the method.
* Implemented logic to iterate through `workplace.input_workplace_list` and append workplace-to-workplace relationship lines to the mermaid diagram.