### PR TITLE
remove is_ready() from BaseCompoent

### DIFF
--- a/pDESy/model/base_component.py
+++ b/pDESy/model/base_component.py
@@ -175,43 +175,6 @@ class BaseComponent(object, metaclass=abc.ABCMeta):
         self.child_component_id_list.append(child_component.ID)
         child_component.parent_product_id = self.parent_product_id
 
-    def is_ready(self):
-        """
-        Check READY component or not.
-
-        READY component is defined by satisfying the following conditions:
-
-          - All tasks are not NONE.
-          - There is no WORKING task in this component.
-          - The states of append_targeted_task includes READY.
-
-        Returns:
-            bool: this component is READY or not.
-        """
-        all_none_flag = all(
-            [task.state == BaseTaskState.NONE for task in self.targeted_task_list]
-        )
-
-        any_working_flag = any(
-            [task.state == BaseTaskState.WORKING for task in self.targeted_task_list]
-        )
-
-        any_ready_flag = any(
-            [task.state == BaseTaskState.READY for task in self.targeted_task_list]
-        )
-
-        all_finished_flag = all(
-            [task.state == BaseTaskState.FINISHED for task in self.targeted_task_list]
-        )
-
-        if all_finished_flag:
-            return False
-
-        if not all_none_flag and (not any_working_flag) and any_ready_flag:
-            return True
-
-        return False
-
     def extend_targeted_task_list(self, targeted_task_list):
         """
         Extend the list of targeted tasks to `targeted_task_list`.

--- a/tests/model/test_base_component.py
+++ b/tests/model/test_base_component.py
@@ -65,32 +65,6 @@ def test_append_child_component():
     assert c1.child_component_id_list == [c2.ID]
 
 
-def test_is_ready():
-    """test_is_ready."""
-    c = BaseComponent("c")
-    task1 = BaseTask("task1")
-    task2 = BaseTask("task2")
-    c.extend_targeted_task_list([task1, task2])
-    assert c.is_ready() is False
-
-    # case 1
-    task1.state = BaseTaskState.READY
-    assert c.is_ready() is True
-
-    # case 2
-    task2.state = BaseTaskState.WORKING
-    assert c.is_ready() is False
-
-    # case 3
-    task2.state = BaseTaskState.FINISHED
-    assert c.is_ready() is True
-
-    # case 4
-    task1.state = BaseTaskState.FINISHED
-    task2.state = BaseTaskState.FINISHED
-    assert c.is_ready() is False
-
-
 def test_extend_targeted_task_list():
     """test_extend_targeted_task_list."""
     c = BaseComponent("c")


### PR DESCRIPTION
This pull request refactors how the "ready" state is determined for components by moving the `is_ready` logic out of the `BaseComponent` class and into the `BaseProject` class as `is_ready_component`. The corresponding method call is updated throughout the codebase, and the now-obsolete tests and method are removed. This centralizes the logic and aligns it with project-level responsibilities.

### Refactoring and code organization

* Removed the `is_ready` method from `BaseComponent`, moving the responsibility for checking if a component is ready to the project level. (`pDESy/model/base_component.py`)
* Added a new `is_ready_component` method to `BaseProject` with the same logic previously in `BaseComponent.is_ready`. (`pDESy/model/base_project.py`)

### Code usage updates

* Updated all usages of `component.is_ready()` to use the new `self.is_ready_component(component)` method in `BaseProject`. (`pDESy/model/base_project.py`)

### Test cleanup

* Removed the `test_is_ready` unit test, as the method it tested (`BaseComponent.is_ready`) has been removed. (`tests/model/test_base_component.py`)