### PR TITLE
remove_output_workplace_list

### DIFF
--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -666,7 +666,8 @@ class BaseProject(object, metaclass=ABCMeta):
                 if hasattr(workplace, "original_input_workplace_list"):
                     del workplace.original_input_workplace_list
                 if hasattr(workplace, "original_output_workplace_list"):
-                    del workplace.original_output_workplace_list
+                if hasattr(workplace, "original_input_workplace_list"):
+                    del workplace.original_input_workplace_list
 
     def reverse_log_information(self):
         """Reverse log information of all."""

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -590,7 +590,8 @@ class BaseProject(object, metaclass=ABCMeta):
             tmp_output = getattr(workplace, "output_workplace_list", [])
             tmp_input = getattr(workplace, "input_workplace_list", [])
             setattr(workplace, "output_workplace_list", tmp_input)
-            setattr(workplace, "input_workplace_list", tmp_output)
+            tmp_input = getattr(workplace, "input_workplace_list", [])
+            setattr(workplace, "input_workplace_list", [])
 
         auto_task_removing_after_simulation = set()
         try:

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -655,16 +655,16 @@ class BaseProject(object, metaclass=ABCMeta):
                 setattr(
                     workplace,
                     "input_workplace_list",
-                    getattr(workplace, "_original_input_workplace_list", []),
+                    getattr(workplace, "original_input_workplace_list", []),
                 )
                 setattr(
                     workplace,
                     "output_workplace_list",
-                    getattr(workplace, "_original_output_workplace_list", []),
+                    getattr(workplace, "original_output_workplace_list", []),
                 )
-                if hasattr(workplace, "_original_input_workplace_list"):
+                if hasattr(workplace, "original_input_workplace_list"):
                     del workplace.original_input_workplace_list
-                if hasattr(workplace, "_original_output_workplace_list"):
+                if hasattr(workplace, "original_output_workplace_list"):
                     del workplace.original_output_workplace_list
 
     def reverse_log_information(self):

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -666,8 +666,7 @@ class BaseProject(object, metaclass=ABCMeta):
                 if hasattr(workplace, "original_input_workplace_list"):
                     del workplace.original_input_workplace_list
                 if hasattr(workplace, "original_output_workplace_list"):
-                if hasattr(workplace, "original_input_workplace_list"):
-                    del workplace.original_input_workplace_list
+                    del workplace.original_output_workplace_list
 
     def reverse_log_information(self):
         """Reverse log information of all."""

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -581,15 +581,16 @@ class BaseProject(object, metaclass=ABCMeta):
 
         # reverse_dependency of workplace
         for workplace in self.workplace_list:
-            workplace.dummy_output_workplace_list = workplace.input_workplace_list
-            workplace.dummy_input_workplace_list = workplace.output_workplace_list
-        for workplace in self.workplace_list:
-            workplace.output_workplace_list = workplace.dummy_output_workplace_list
-            workplace.input_workplace_list = workplace.dummy_input_workplace_list
-            del (
-                workplace.dummy_output_workplace_list,
-                workplace.dummy_input_workplace_list,
+            workplace.original_input_workplace_list = getattr(
+                workplace, "input_workplace_list", []
             )
+            workplace.original_output_workplace_list = getattr(
+                workplace, "output_workplace_list", []
+            )
+            tmp_output = getattr(workplace, "output_workplace_list", [])
+            tmp_input = getattr(workplace, "input_workplace_list", [])
+            setattr(workplace, "output_workplace_list", tmp_input)
+            setattr(workplace, "input_workplace_list", tmp_output)
 
         auto_task_removing_after_simulation = set()
         try:
@@ -651,15 +652,20 @@ class BaseProject(object, metaclass=ABCMeta):
 
             # reverse_dependency of workplace
             for workplace in self.workplace_list:
-                workplace.dummy_output_workplace_list = workplace.input_workplace_list
-                workplace.dummy_input_workplace_list = workplace.output_workplace_list
-            for workplace in self.workplace_list:
-                workplace.output_workplace_list = workplace.dummy_output_workplace_list
-                workplace.input_workplace_list = workplace.dummy_input_workplace_list
-                del (
-                    workplace.dummy_output_workplace_list,
-                    workplace.dummy_input_workplace_list,
+                setattr(
+                    workplace,
+                    "input_workplace_list",
+                    getattr(workplace, "_original_input_workplace_list", []),
                 )
+                setattr(
+                    workplace,
+                    "output_workplace_list",
+                    getattr(workplace, "_original_output_workplace_list", []),
+                )
+                if hasattr(workplace, "_original_input_workplace_list"):
+                    del workplace.original_input_workplace_list
+                if hasattr(workplace, "_original_output_workplace_list"):
+                    del workplace.original_output_workplace_list
 
     def reverse_log_information(self):
         """Reverse log information of all."""

--- a/pDESy/model/base_workplace.py
+++ b/pDESy/model/base_workplace.py
@@ -51,10 +51,6 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
             Basic parameter.
             List of input BaseWorkplace.
             Defaults to None -> [].
-        output_workplace_list (List[BaseWorkplace], optional):
-            Basic parameter.
-            List of input BaseWorkplace.
-            Defaults to None -> [].
         placed_component_list (List[BaseComponent], optional):
             Basic variable.
             Components which places to this workplace in simulation.
@@ -79,7 +75,6 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         parent_workplace_id=None,
         max_space_size=None,
         input_workplace_list=None,
-        output_workplace_list=None,
         # Basic variables
         cost_list=None,
         placed_component_list=None,
@@ -108,9 +103,6 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
 
         self.input_workplace_list = (
             input_workplace_list if input_workplace_list is not None else []
-        )
-        self.output_workplace_list = (
-            output_workplace_list if output_workplace_list is not None else []
         )
 
         # ----
@@ -380,9 +372,6 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
             input_workplace_list=[
                 w.ID for w in self.input_workplace_list if w is not None
             ],
-            output_workplace_list=[
-                w.ID for w in self.output_workplace_list if w is not None
-            ],
             cost_list=self.cost_list,
             placed_component_list=[c.ID for c in self.placed_component_list],
             placed_component_id_record=self.placed_component_id_record,
@@ -422,7 +411,6 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         self.parent_workplace_id = json_data["parent_workplace_id"]
         self.max_space_size = json_data["max_space_size"]
         self.input_workplace_list = json_data["input_workplace_list"]
-        self.output_workplace_list = json_data["output_workplace_list"]
         # Basic variables
         self.cost_list = json_data["cost_list"]
         self.placed_component_list = json_data["placed_component_list"]
@@ -1107,11 +1095,8 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
             >>> workplace.append_input_task_dependency(workplace1)
             >>> print([input_w.name for input_w in workplace.input_workplace_list])
             ['workplace1']
-            >>> print([parent_w.name for parent_w in workplace1.output_workplace_list])
-            ['workplace']
         """
         self.input_workplace_list.append(input_workplace)
-        input_workplace.output_workplace_list.append(self)
 
     def extend_input_workplace_list(self, input_workplace_list):
         """
@@ -1130,7 +1115,6 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         """
         for input_workplace in input_workplace_list:
             self.input_workplace_list.append(input_workplace)
-            input_workplace.output_workplace_list.append(self)
 
     def get_target_facility_mermaid_diagram(
         self,

--- a/tests/model/test_base_workplace.py
+++ b/tests/model/test_base_workplace.py
@@ -22,7 +22,6 @@ def test_init():
     assert workplace.targeted_task_id_list == []
     assert workplace.parent_workplace_id is None
     assert workplace.input_workplace_list == []
-    assert workplace.output_workplace_list == []
     assert workplace.cost_list == []
     workplace.cost_list.append(1)
     assert workplace.cost_list == [1.0]
@@ -386,8 +385,6 @@ def test_append_input_workplace():
     workplace.append_input_workplace(workplace1)
     workplace.append_input_workplace(workplace2)
     assert workplace.input_workplace_list == [workplace1, workplace2]
-    assert workplace1.output_workplace_list == [workplace]
-    assert workplace2.output_workplace_list == [workplace]
 
 
 def test_extend_input_workplace_list():
@@ -397,8 +394,6 @@ def test_extend_input_workplace_list():
     workplace2 = BaseWorkplace("workplace2")
     workplace2.extend_input_workplace_list([workplace11, workplace12])
     assert workplace2.input_workplace_list == [workplace11, workplace12]
-    assert workplace11.output_workplace_list == [workplace2]
-    assert workplace12.output_workplace_list == [workplace2]
 
 
 def test_remove_insert_absence_time_list():


### PR DESCRIPTION
This pull request refactors the handling of workplace dependencies in the simulation model, specifically removing the concept of an explicit `output_workplace_list` from the `BaseWorkplace` class and related logic. The changes simplify the data model and update the simulation and tests accordingly.

### Refactoring of workplace dependency management

* Removed the `output_workplace_list` attribute and all related logic from the `BaseWorkplace` class, including its initialization, serialization, deserialization, and methods that previously maintained both input and output workplace lists. [[1]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL54-L57) [[2]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL82) [[3]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL112-L114) [[4]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL383-L385) [[5]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL425) [[6]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL1110-L1114) [[7]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL1133)
* Updated the `backward_simulate` method in `base_project.py` to reverse dependencies by swapping `input_workplace_list` and `output_workplace_list` using temporary attributes, and then restoring them, now relying only on input lists. [[1]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL584-R593) [[2]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL654-R668)

### Test updates

* Removed assertions and test logic related to `output_workplace_list` to align with the refactored data model. [[1]](diffhunk://#diff-fc392764fd10e56136e89f68c4320e0d8b4c262ea3d96d01029b4ac7639500a3L25) [[2]](diffhunk://#diff-fc392764fd10e56136e89f68c4320e0d8b4c262ea3d96d01029b4ac7639500a3L389-L390) [[3]](diffhunk://#diff-fc392764fd10e56136e89f68c4320e0d8b4c262ea3d96d01029b4ac7639500a3L400-L401)