### PR TITLE
Refactor/base workplace/add available space size attr

### DIFF
--- a/pDESy/model/base_priority_rule.py
+++ b/pDESy/model/base_priority_rule.py
@@ -54,7 +54,7 @@ def sort_workplace_list(
     if priority_rule_mode == WorkplacePriorityRuleMode.FSS:
         workplace_list = sorted(
             workplace_list,
-            key=lambda workplace: workplace.get_available_space_size(),
+            key=lambda workplace: workplace.available_space_size,
             reverse=True,
         )
     # SSP: Sum Skill Points of targeted task

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -1614,6 +1614,7 @@ class BaseProject(object, metaclass=ABCMeta):
         if placed_workplace is not None:
             if target_component not in placed_workplace.placed_component_list:
                 placed_workplace.placed_component_list.append(target_component)
+                placed_workplace.available_space_size -= target_component.space_size
 
         if set_to_all_children:
             for child_c_id in target_component.child_component_id_list:
@@ -1641,6 +1642,7 @@ class BaseProject(object, metaclass=ABCMeta):
                 Default to True
         """
         placed_workplace.placed_component_list.remove(target_component)
+        placed_workplace.available_space_size += target_component.space_size
 
         if set_to_all_children:
             for child_c_id in target_component.child_component_id_list:

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -1004,7 +1004,9 @@ class BaseProject(object, metaclass=ABCMeta):
 
                             if (
                                 conveyor_condition
-                                and workplace.can_put(component)
+                                and self.can_put_component_to_workplace(
+                                    workplace, component
+                                )
                                 and skill_flag
                             ):
                                 # 3-1-1. move ready_component
@@ -1399,6 +1401,29 @@ class BaseProject(object, metaclass=ABCMeta):
                                 facility.state = BaseFacilityState.FREE
                                 facility.assigned_task_id_list.remove(task.ID)
                     task.allocated_facility_id_list = []
+
+    def can_put_component_to_workplace(
+        self, workplace: BaseWorkplace, component: BaseComponent, error_tol=1e-8
+    ):
+        """
+        Check whether the target component can be put to this workplace in this time.
+
+        Args:
+            workplace (BaseWorkplace):
+                Target workplace for checking.
+            component (BaseComponent):
+                BaseComponent
+            error_tol (float, optional):
+                Measures against numerical error.
+                Defaults to 1e-8.
+
+        Returns:
+            bool: whether the target component can be put to this workplace in this time
+        """
+        can_put = False
+        if workplace.available_space_size > component.space_size - error_tol:
+            can_put = True
+        return can_put
 
     def can_add_resources_to_task(self, task: BaseTask, worker=None, facility=None):
         """

--- a/pDESy/model/base_workplace.py
+++ b/pDESy/model/base_workplace.py
@@ -51,6 +51,10 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
             Basic parameter.
             List of input BaseWorkplace.
             Defaults to None -> [].
+        available_space_size (float, optional):
+            Basic variable.
+            Available space size in this workplace.
+            Defaults to None -> max_space_size.
         placed_component_list (List[BaseComponent], optional):
             Basic variable.
             Components which places to this workplace in simulation.
@@ -76,6 +80,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         max_space_size=None,
         input_workplace_list=None,
         # Basic variables
+        available_space_size=None,
         cost_list=None,
         placed_component_list=None,
         placed_component_id_record=None,
@@ -113,6 +118,11 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
             self.cost_list = cost_list
         else:
             self.cost_list = []
+
+        if available_space_size is not None:
+            self.available_space_size = available_space_size
+        else:
+            self.available_space_size = self.max_space_size
 
         if placed_component_list is not None:
             self.placed_component_list = placed_component_list
@@ -227,19 +237,9 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
             bool: whether the target component can be put to this workplace in this time
         """
         can_put = False
-        if self.get_available_space_size() > component.space_size - error_tol:
+        if self.available_space_size > component.space_size - error_tol:
             can_put = True
         return can_put
-
-    def get_available_space_size(self):
-        """
-        Get available space size in this time.
-
-        Returns:
-            float: available space size in this time
-        """
-        use_space_size = sum([c.space_size for c in self.placed_component_list])
-        return self.max_space_size - use_space_size
 
     def initialize(self, state_info=True, log_info=True):
         """

--- a/pDESy/model/base_workplace.py
+++ b/pDESy/model/base_workplace.py
@@ -222,25 +222,6 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         self.targeted_task_id_list.append(targeted_task.ID)
         targeted_task.allocated_workplace_id_list.append(self.ID)
 
-    def can_put(self, component, error_tol=1e-8):
-        """
-        Check whether the target component can be put to this workplace in this time.
-
-        Args:
-            component (BaseComponent):
-                BaseComponent
-            error_tol (float, optional):
-                Measures against numerical error.
-                Defaults to 1e-8.
-
-        Returns:
-            bool: whether the target component can be put to this workplace in this time
-        """
-        can_put = False
-        if self.available_space_size > component.space_size - error_tol:
-            can_put = True
-        return can_put
-
     def initialize(self, state_info=True, log_info=True):
         """
         Initialize the following changeable variables of BaseWorkplace.

--- a/tests/model/test_base_workplace.py
+++ b/tests/model/test_base_workplace.py
@@ -127,21 +127,6 @@ def test_add_facility():
     assert facility.workplace_id == workplace.ID
 
 
-def test_can_put():
-    """test_can_put."""
-    c1 = BaseComponent("c1", space_size=2.0)
-    c2 = BaseComponent("c2", space_size=2.0)
-    workplace = BaseWorkplace("f", max_space_size=1.0)
-    assert workplace.can_put(c1) is False
-    assert workplace.can_put(c2) is False
-    workplace.max_space_size = 3.0
-    workplace.available_space_size = 3.0
-    assert workplace.can_put(c1) is True
-    assert workplace.can_put(c2) is True
-    workplace.max_space_size = 4.0
-    assert workplace.can_put(c2) is True
-
-
 def test_extend_targeted_task_list():
     """test_extend_targeted_task_list."""
     workplace = BaseWorkplace("workplace")

--- a/tests/model/test_base_workplace.py
+++ b/tests/model/test_base_workplace.py
@@ -135,17 +135,11 @@ def test_can_put():
     assert workplace.can_put(c1) is False
     assert workplace.can_put(c2) is False
     workplace.max_space_size = 3.0
+    workplace.available_space_size = 3.0
     assert workplace.can_put(c1) is True
     assert workplace.can_put(c2) is True
     workplace.max_space_size = 4.0
     assert workplace.can_put(c2) is True
-
-
-def test_get_available_space_size():
-    """test_get_available_space_size."""
-    max_space_size = 5.0
-    workplace = BaseWorkplace("f", max_space_size=max_space_size)
-    assert workplace.get_available_space_size() == max_space_size
 
 
 def test_extend_targeted_task_list():


### PR DESCRIPTION
This pull request refactors how available space is tracked and checked for workplaces, moving from a dynamic calculation to a dedicated variable. It also centralizes the logic for checking if a component can be placed into a workplace, and ensures the available space is updated when components are added or removed. Some redundant methods and their associated tests are removed for clarity and maintainability.

**Refactoring available space management:**
- Introduced the `available_space_size` variable in `BaseWorkplace`, initializing it to `max_space_size` unless specified, and updated its value directly when components are added or removed (`base_workplace.py`, `base_project.py`). [[1]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cR54-R57) [[2]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cR83) [[3]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cR122-R126) [[4]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR1642) [[5]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR1670)

**Centralizing placement logic:**
- Moved the logic for checking if a component can be placed on a workplace from `BaseWorkplace.can_put` to a new method `BaseProject.can_put_component_to_workplace`, and updated all usages accordingly (`base_project.py`). [[1]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL1007-R1009) [[2]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR1405-R1427)

**Code and test cleanup:**
- Removed the `can_put` and `get_available_space_size` methods from `BaseWorkplace`, as well as their associated tests, since this logic is now handled elsewhere and with the new variable (`base_workplace.py`, `test_base_workplace.py`). [[1]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL215-L243) [[2]](diffhunk://#diff-fc392764fd10e56136e89f68c4320e0d8b4c262ea3d96d01029b4ac7639500a3L130-L150)

**Other updates:**
- Updated sorting in `sort_workplace_list` to use the new `available_space_size` property directly instead of the removed method (`base_priority_rule.py`).