### PR TITLE
Refactor/base workplace/placed component list

### DIFF
--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -1038,7 +1038,15 @@ class BaseProject(object, metaclass=ABCMeta):
                                             None,
                                         )
                                         if wp is not None:
-                                            for c_wp in wp.placed_component_list:
+                                            for c_wp_id in wp.placed_component_id_list:
+                                                c_wp = next(
+                                                    (
+                                                        c
+                                                        for c in self.get_all_component_list()
+                                                        if c.ID == c_wp_id
+                                                    ),
+                                                    None,
+                                                )
                                                 if any(
                                                     child_id == task.target_component_id
                                                     for child_id in c_wp.child_component_id_list
@@ -1637,8 +1645,8 @@ class BaseProject(object, metaclass=ABCMeta):
             placed_workplace.ID if placed_workplace else None
         )
         if placed_workplace is not None:
-            if target_component not in placed_workplace.placed_component_list:
-                placed_workplace.placed_component_list.append(target_component)
+            if target_component.ID not in placed_workplace.placed_component_id_list:
+                placed_workplace.placed_component_id_list.append(target_component.ID)
                 placed_workplace.available_space_size -= target_component.space_size
 
         if set_to_all_children:
@@ -1666,7 +1674,7 @@ class BaseProject(object, metaclass=ABCMeta):
                 If True, remove `placed_workplace` to all children components
                 Default to True
         """
-        placed_workplace.placed_component_list.remove(target_component)
+        placed_workplace.placed_component_id_list.remove(target_component.ID)
         placed_workplace.available_space_size += target_component.space_size
 
         if set_to_all_children:
@@ -2726,10 +2734,10 @@ class BaseProject(object, metaclass=ABCMeta):
                 if x.parent_workplace_id is not None
                 else None
             )
-            x.placed_component_list = [
-                component
+            x.placed_component_id_list = [
+                component.ID
                 for component in all_component_list
-                if component.ID in x.placed_component_list
+                if component.ID in x.placed_component_id_list
             ]
             for f in x.facility_list:
                 f.assigned_task_id_list = [
@@ -2880,7 +2888,9 @@ class BaseProject(object, metaclass=ABCMeta):
                     )
                 )[0]
                 workplace.cost_list.extend(workplace_j["cost_list"])
-                workplace.placed_component_list = workplace_j["placed_component_list"]
+                workplace.placed_component_id_list = workplace_j[
+                    "placed_component_id_list"
+                ]
                 workplace.placed_component_id_record.extend(
                     workplace_j["placed_component_id_record"]
                 )

--- a/pDESy/model/base_workplace.py
+++ b/pDESy/model/base_workplace.py
@@ -246,6 +246,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         """
         if state_info:
             self.placed_component_id_list = []
+            self.available_space_size = self.max_space_size
         if log_info:
             self.cost_list = []
             self.placed_component_id_record = []

--- a/pDESy/model/base_workplace.py
+++ b/pDESy/model/base_workplace.py
@@ -55,9 +55,9 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
             Basic variable.
             Available space size in this workplace.
             Defaults to None -> max_space_size.
-        placed_component_list (List[BaseComponent], optional):
+        placed_component_id_list (List[str], optional):
             Basic variable.
-            Components which places to this workplace in simulation.
+            Components id which places to this workplace in simulation.
             Defaults to None -> [].
         placed_component_id_record(List[List[str]], optional):
             Basic variable.
@@ -82,7 +82,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         # Basic variables
         available_space_size=None,
         cost_list=None,
-        placed_component_list=None,
+        placed_component_id_list=None,
         placed_component_id_record=None,
     ):
         """init."""
@@ -124,10 +124,10 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         else:
             self.available_space_size = self.max_space_size
 
-        if placed_component_list is not None:
-            self.placed_component_list = placed_component_list
+        if placed_component_id_list is not None:
+            self.placed_component_id_list = placed_component_id_list
         else:
-            self.placed_component_list = []
+            self.placed_component_id_list = []
 
         if placed_component_id_record is not None:
             self.placed_component_id_record = placed_component_id_record
@@ -228,7 +228,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
 
         If `state_info` is True, the following attributes are initialized.
 
-          - `placed_component_list`
+          - `placed_component_id_list`
 
         If `log_info` is True, the following attributes are initialized.
           - `cost_list`
@@ -245,7 +245,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
                 Defaults to True.
         """
         if state_info:
-            self.placed_component_list = []
+            self.placed_component_id_list = []
         if log_info:
             self.cost_list = []
             self.placed_component_id_record = []
@@ -307,9 +307,8 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
     def record_placed_component_id(self):
         """Record component id list to `placed_component_id_record`."""
         record = []
-        if len(self.placed_component_list) > 0:
-            # print([c for c in self.placed_component_list])
-            record = [c.ID for c in self.placed_component_list]
+        if len(self.placed_component_id_list) > 0:
+            record = self.placed_component_id_list
 
         self.placed_component_id_record.append(record)
 
@@ -354,7 +353,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
                 w.ID for w in self.input_workplace_list if w is not None
             ],
             cost_list=self.cost_list,
-            placed_component_list=[c.ID for c in self.placed_component_list],
+            placed_component_id_list=self.placed_component_id_list,
             placed_component_id_record=self.placed_component_id_record,
         )
         return dict_json_data
@@ -394,7 +393,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         self.input_workplace_list = json_data["input_workplace_list"]
         # Basic variables
         self.cost_list = json_data["cost_list"]
-        self.placed_component_list = json_data["placed_component_list"]
+        self.placed_component_id_list = json_data["placed_component_id_list"]
         self.placed_component_id_record = json_data["placed_component_id_record"]
 
     def extract_free_facility_list(self, target_time_list):

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -903,30 +903,6 @@ def test_component_place_check_2(dummy_conveyor_project_with_child_component):
         max_time=100,
     )
 
-    component_wp1_list = []
-    wp1 = dummy_conveyor_project_with_child_component.workplace_list[0]
-    wp1_c_id_record = wp1.placed_component_id_record
-    for c_id_record in wp1_c_id_record:
-        component_wp1_list.extend(c_id_record)
-
-    component_wp2_list = []
-    wp2 = dummy_conveyor_project_with_child_component.workplace_list[1]
-    wp2_c_id_record = wp2.placed_component_id_record
-    for c_id_record in wp2_c_id_record:
-        component_wp2_list.extend(c_id_record)
-
-    component_wp3_list = []
-    wp3 = dummy_conveyor_project_with_child_component.workplace_list[2]
-    wp3_c_id_record = wp3.placed_component_id_record
-    for c_id_record in wp3_c_id_record:
-        component_wp3_list.extend(c_id_record)
-
-    component_wp4_list = []
-    wp4 = dummy_conveyor_project_with_child_component.workplace_list[3]
-    wp4_c_id_record = wp4.placed_component_id_record
-    for c_id_record in wp4_c_id_record:
-        component_wp4_list.extend(c_id_record)
-
     # backward
     dummy_conveyor_project_with_child_component.backward_simulate(
         max_time=100,

--- a/tests/model/test_base_workplace.py
+++ b/tests/model/test_base_workplace.py
@@ -35,7 +35,7 @@ def test_init():
         facility_list=[w1],
         max_space_size=2.0,
         cost_list=[10],
-        placed_component_list=[BaseComponent("c")],
+        placed_component_id_list=[BaseComponent("c").ID],
         placed_component_id_record=["xxxx"],
     )
     assert workplace1.facility_list == [w1]
@@ -43,7 +43,6 @@ def test_init():
     assert workplace1.parent_workplace_id == workplace.ID
     assert workplace1.max_space_size == 2.0
     assert workplace1.cost_list == [10]
-    assert workplace1.placed_component_list[0].name == "c"
     assert workplace1.placed_component_id_record == ["xxxx"]
 
 


### PR DESCRIPTION
This pull request refactors how components placed on a workplace are tracked throughout the codebase. Instead of storing component objects directly in each workplace, the code now consistently stores only their IDs. This change simplifies serialization, improves consistency, and reduces memory usage. The update touches core model logic, data import/export, and related tests.

**Core Model Refactor:**

* Replaced `placed_component_list` (list of component objects) with `placed_component_id_list` (list of component IDs) throughout `BaseWorkplace` and related logic, including initialization, state management, and documentation. [[1]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL58-R60) [[2]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL85-R85) [[3]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL127-R130) [[4]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL231-R231) [[5]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL248-R249) [[6]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL310-R312)

**Data Handling:**

* Updated JSON serialization and deserialization methods in both `BaseWorkplace` and `BaseProject` to use `placed_component_id_list` instead of `placed_component_list`, ensuring correct import/export of workplace state. [[1]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL357-R357) [[2]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL397-R397) [[3]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL2729-R2740) [[4]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL2883-R2893)

**Component Placement Logic:**

* Modified methods for adding and removing components to workplaces to operate on component IDs rather than component objects, ensuring consistency and preventing object reference issues. [[1]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL1041-R1049) [[2]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL1640-R1649) [[3]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL1669-R1677)

**Testing Updates:**

* Refactored tests to use `placed_component_id_list` and removed references to the old `placed_component_list`, ensuring tests align with the new data structure. [[1]](diffhunk://#diff-fc392764fd10e56136e89f68c4320e0d8b4c262ea3d96d01029b4ac7639500a3L38-L46) [[2]](diffhunk://#diff-9d7964630fe34043135004bf01fbb8d8dfbf6c1a11da850ce2fcc9f2619e4ab5L906-L929)