### PR TITLE
Refactor/base workplace/input workplace list

### DIFF
--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -581,17 +581,16 @@ class BaseProject(object, metaclass=ABCMeta):
 
         # reverse_dependency of workplace
         for workplace in self.workplace_list:
-            workplace.original_input_workplace_list = getattr(
-                workplace, "input_workplace_list", []
+            workplace.original_input_workplace_id_list = getattr(
+                workplace, "input_workplace_id_list", []
             )
-            workplace.original_output_workplace_list = getattr(
-                workplace, "output_workplace_list", []
+            workplace.original_output_workplace_id_list = getattr(
+                workplace, "output_workplace_id_list", []
             )
-            tmp_output = getattr(workplace, "output_workplace_list", [])
-            tmp_input = getattr(workplace, "input_workplace_list", [])
-            setattr(workplace, "output_workplace_list", tmp_input)
-            tmp_input = getattr(workplace, "input_workplace_list", [])
-            setattr(workplace, "input_workplace_list", [])
+            tmp_input = getattr(workplace, "input_workplace_id_list", [])
+            setattr(workplace, "output_workplace_id_list", tmp_input)
+            tmp_input = getattr(workplace, "input_workplace_id_list", [])
+            setattr(workplace, "input_workplace_id_list", [])
 
         auto_task_removing_after_simulation = set()
         try:
@@ -655,18 +654,18 @@ class BaseProject(object, metaclass=ABCMeta):
             for workplace in self.workplace_list:
                 setattr(
                     workplace,
-                    "input_workplace_list",
-                    getattr(workplace, "original_input_workplace_list", []),
+                    "input_workplace_id_list",
+                    getattr(workplace, "original_input_workplace_id_list", []),
                 )
                 setattr(
                     workplace,
-                    "output_workplace_list",
-                    getattr(workplace, "original_output_workplace_list", []),
+                    "output_workplace_id_list",
+                    getattr(workplace, "original_output_workplace_id_list", []),
                 )
-                if hasattr(workplace, "original_input_workplace_list"):
-                    del workplace.original_input_workplace_list
-                if hasattr(workplace, "original_output_workplace_list"):
-                    del workplace.original_output_workplace_list
+                if hasattr(workplace, "original_input_workplace_id_list"):
+                    del workplace.original_input_workplace_id_list
+                if hasattr(workplace, "original_output_workplace_id_list"):
+                    del workplace.original_output_workplace_id_list
 
     def reverse_log_information(self):
         """Reverse log information of all."""
@@ -983,14 +982,14 @@ class BaseProject(object, metaclass=ABCMeta):
                     for workplace in candidate_workplace_list:
                         if workplace.ID in target_workplace_id_list:
                             conveyor_condition = True
-                            if len(workplace.input_workplace_list) > 0:
+                            if len(workplace.input_workplace_id_list) > 0:
                                 if component.placed_workplace_id is None:
                                     conveyor_condition = True
                                 elif not (
                                     component.placed_workplace_id
                                     in [
-                                        workplace.ID
-                                        for workplace in workplace.input_workplace_list
+                                        workplace_id
+                                        for workplace_id in workplace.input_workplace_id_list
                                     ]
                                 ):
                                     conveyor_condition = False
@@ -3087,9 +3086,9 @@ class BaseProject(object, metaclass=ABCMeta):
 
         # workplace -> workplace
         for workplace in target_workplace_list:
-            for input_workplace in workplace.input_workplace_list:
+            for input_workplace_id in workplace.input_workplace_id_list:
                 list_of_lines.append(
-                    f"{input_workplace.ID}{link_type_str_workplace_workplace}{workplace.ID}"
+                    f"{input_workplace_id}{link_type_str_workplace_workplace}{workplace.ID}"
                 )
 
         if subgraph:
@@ -5559,9 +5558,9 @@ class BaseProject(object, metaclass=ABCMeta):
             )
         # workplace -> workplace
         for workplace in self.workplace_list:
-            for input_workplace in workplace.input_workplace_list:
+            for input_workplace_id in workplace.input_workplace_id_list:
                 list_of_lines.append(
-                    f"{input_workplace.ID}{link_type_str_workplace_workplace}{workplace.ID}"
+                    f"{input_workplace_id}{link_type_str_workplace_workplace}{workplace.ID}"
                 )
 
         return list_of_lines

--- a/pDESy/model/base_workplace.py
+++ b/pDESy/model/base_workplace.py
@@ -47,9 +47,9 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
             Basic parameter
             Max size of space for placing components
             Default to None -> 1.0
-        input_workplace_list (List[BaseWorkplace], optional):
+        input_workplace_id_list (List[str], optional):
             Basic parameter.
-            List of input BaseWorkplace.
+            List of input BaseWorkplace id.
             Defaults to None -> [].
         placed_component_list (List[BaseComponent], optional):
             Basic variable.
@@ -74,7 +74,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         targeted_task_id_list=None,
         parent_workplace_id=None,
         max_space_size=None,
-        input_workplace_list=None,
+        input_workplace_id_list=None,
         # Basic variables
         cost_list=None,
         placed_component_list=None,
@@ -101,8 +101,8 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         )
         self.max_space_size = max_space_size if max_space_size is not None else np.inf
 
-        self.input_workplace_list = (
-            input_workplace_list if input_workplace_list is not None else []
+        self.input_workplace_id_list = (
+            input_workplace_id_list if input_workplace_id_list is not None else []
         )
 
         # ----
@@ -369,8 +369,8 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
                 else None
             ),
             max_space_size=self.max_space_size,
-            input_workplace_list=[
-                w.ID for w in self.input_workplace_list if w is not None
+            input_workplace_id_list=[
+                w_id for w_id in self.input_workplace_id_list if w_id is not None
             ],
             cost_list=self.cost_list,
             placed_component_list=[c.ID for c in self.placed_component_list],
@@ -410,7 +410,7 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         self.targeted_task_id_list = json_data["targeted_task_id_list"]
         self.parent_workplace_id = json_data["parent_workplace_id"]
         self.max_space_size = json_data["max_space_size"]
-        self.input_workplace_list = json_data["input_workplace_list"]
+        self.input_workplace_id_list = json_data["input_workplace_id_list"]
         # Basic variables
         self.cost_list = json_data["cost_list"]
         self.placed_component_list = json_data["placed_component_list"]
@@ -1082,39 +1082,24 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
 
     def append_input_workplace(self, input_workplace):
         """
-        Append input workplace to `input_workplace_list`.
+        Append input workplace to `input_workplace_id_list`.
 
         Args:
             input_workplace (BaseWorkplace):
                 input workplace
-        Examples:
-           >>> workplace = BaseWorkplace("workplace")
-            >>> print([input_w.name for input_w in workplace.input_workplace_list])
-            []
-            >>> workplace1 = BaseWorkplace("workplace1")
-            >>> workplace.append_input_task_dependency(workplace1)
-            >>> print([input_w.name for input_w in workplace.input_workplace_list])
-            ['workplace1']
         """
-        self.input_workplace_list.append(input_workplace)
+        self.input_workplace_id_list.append(input_workplace.ID)
 
     def extend_input_workplace_list(self, input_workplace_list):
         """
-        Extend the list of input workplaces to `input_workplace_list`.
+        Extend the list of input workplaces to `input_workplace_id_list`.
 
         Args:
             input_workplace_list (list[BaseWorkplace]):
                  List of input workplaces
-        Examples:
-           >>> workplace = BaseWorkplace('workplace')
-            >>> print([input_w.name for input_w in workplace.input_workplace_list])
-            []
-            >>> workplace.extend_input_workplace_list([BaseWorkplace('wp1'),Base('wp2')])
-            >>> print([input_w.name for input_t in workplace.input_workplace_list])
-            ['wp1', 'wp2']
         """
         for input_workplace in input_workplace_list:
-            self.input_workplace_list.append(input_workplace)
+            self.append_input_workplace(input_workplace)
 
     def get_target_facility_mermaid_diagram(
         self,

--- a/tests/model/test_base_workplace.py
+++ b/tests/model/test_base_workplace.py
@@ -21,7 +21,7 @@ def test_init():
     assert workplace.facility_list == []
     assert workplace.targeted_task_id_list == []
     assert workplace.parent_workplace_id is None
-    assert workplace.input_workplace_list == []
+    assert workplace.input_workplace_id_list == []
     assert workplace.cost_list == []
     workplace.cost_list.append(1)
     assert workplace.cost_list == [1.0]
@@ -384,7 +384,7 @@ def test_append_input_workplace():
     workplace2 = BaseWorkplace("workplace2")
     workplace.append_input_workplace(workplace1)
     workplace.append_input_workplace(workplace2)
-    assert workplace.input_workplace_list == [workplace1, workplace2]
+    assert workplace.input_workplace_id_list == [workplace1.ID, workplace2.ID]
 
 
 def test_extend_input_workplace_list():
@@ -393,7 +393,7 @@ def test_extend_input_workplace_list():
     workplace12 = BaseWorkplace("workplace12")
     workplace2 = BaseWorkplace("workplace2")
     workplace2.extend_input_workplace_list([workplace11, workplace12])
-    assert workplace2.input_workplace_list == [workplace11, workplace12]
+    assert workplace2.input_workplace_id_list == [workplace11.ID, workplace12.ID]
 
 
 def test_remove_insert_absence_time_list():


### PR DESCRIPTION
This pull request refactors the handling of workplace dependencies in the codebase by replacing references to `input_workplace_list` and `output_workplace_list` (which stored workplace objects) with `input_workplace_id_list` and `output_workplace_id_list` (which store workplace IDs as strings). This change simplifies serialization, deserialization, and dependency management, and is reflected across the core logic, data model, and tests.

**Core logic and data model updates:**

* All references to `input_workplace_list` and `output_workplace_list` in `BaseWorkplace` and related logic are replaced with `input_workplace_id_list` and `output_workplace_id_list`, respectively. This includes initialization, attribute assignment, and all methods that previously managed workplace object lists. [[1]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL584-R593) [[2]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL658-R668) [[3]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL81-R81) [[4]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL109-R110)
* Methods that append or extend input workplaces now operate on workplace IDs, and relevant docstrings and examples are updated to reflect this change in `base_workplace.py`.

**Serialization and deserialization:**

* The export and import (JSON serialization) logic for workplaces now uses `input_workplace_id_list` instead of `input_workplace_list`, ensuring that only IDs are serialized/deserialized. [[1]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL353-R354) [[2]](diffhunk://#diff-ef1f3f7c116137bed426486f8387e9d82e009418c669a6a18a4145b307b2546cL394-R394)

**Visualization and allocation logic:**

* All code generating diagrams or handling workplace dependencies (e.g., in `get_target_mermaid_diagram`, `get_all_workplace_mermaid_diagram`, and allocation logic) now uses workplace ID lists rather than workplace object lists. [[1]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL986-R992) [[2]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL3127-R3128) [[3]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cL5599-R5600)

**Testing:**

* All relevant tests are updated to check for lists of workplace IDs rather than workplace objects, ensuring correctness with the new dependency representation. [[1]](diffhunk://#diff-fc392764fd10e56136e89f68c4320e0d8b4c262ea3d96d01029b4ac7639500a3L24-R24) [[2]](diffhunk://#diff-fc392764fd10e56136e89f68c4320e0d8b4c262ea3d96d01029b4ac7639500a3L365-R365) [[3]](diffhunk://#diff-fc392764fd10e56136e89f68c4320e0d8b4c262ea3d96d01029b4ac7639500a3L374-R374)