### PR TITLE
Creating child instance from parent instance

### DIFF
--- a/pDESy/model/base_component.py
+++ b/pDESy/model/base_component.py
@@ -335,7 +335,7 @@ class BaseComponent(object, metaclass=abc.ABCMeta):
                 Basic parameter.
                 Default workamount of this BaseTask.
                 Defaults to None -> 10.0.
-            work_amount_progress_of_unit_step_time (float, optional)
+            work_amount_progress_of_unit_step_time (float, optional):
                 Baseline of work amount progress of unit step time.
                 Default to None -> 1.0.
             input_task_id_dependency_set (set(tuple(str, BaseTaskDependency)), optional):

--- a/pDESy/model/base_component.py
+++ b/pDESy/model/base_component.py
@@ -10,7 +10,11 @@ from enum import IntEnum
 
 import numpy as np
 
-from pDESy.model.base_task import BaseTask
+from pDESy.model.base_priority_rule import (
+    ResourcePriorityRuleMode,
+    WorkplacePriorityRuleMode,
+)
+from pDESy.model.base_task import BaseTask, BaseTaskState
 
 
 class BaseComponentState(IntEnum):
@@ -279,6 +283,203 @@ class BaseComponent(object, metaclass=abc.ABCMeta):
         else:
             self.targeted_task_id_set.add(targeted_task.ID)
             targeted_task.target_component_id = self.ID
+
+    def create_task(
+        self,
+        name=None,
+        ID=None,
+        default_work_amount=None,
+        work_amount_progress_of_unit_step_time=None,
+        input_task_id_dependency_set=None,
+        allocated_team_id_set=None,
+        allocated_workplace_id_set=None,
+        parent_workflow_id=None,
+        workplace_priority_rule=WorkplacePriorityRuleMode.FSS,
+        worker_priority_rule=ResourcePriorityRuleMode.MW,
+        facility_priority_rule=ResourcePriorityRuleMode.SSP,
+        need_facility=False,
+        target_component_id=None,
+        default_progress=None,
+        due_time=None,
+        auto_task=False,
+        fixing_allocating_worker_id_set=None,
+        fixing_allocating_facility_id_set=None,
+        # Basic variables
+        est=0.0,
+        eft=0.0,
+        lst=-1.0,
+        lft=-1.0,
+        remaining_work_amount=None,
+        remaining_work_amount_record_list=None,
+        state=BaseTaskState.NONE,
+        state_record_list=None,
+        allocated_worker_facility_id_tuple_set=None,
+        allocated_worker_facility_id_tuple_set_record_list=None,
+        # Advanced parameters for customized simulation
+        additional_work_amount=None,
+        # Advanced variables for customized simulation
+        additional_task_flag=False,
+        actual_work_amount=None,
+    ):
+        """
+        Create a new BaseTask instance and add it to the targeted tasks.
+        Args:
+            name (str, optional):
+                Basic parameter.
+                Name of this task.
+                Defaults to None -> "New Task".
+            ID (str, optional):
+                Basic parameter.
+                ID will be defined automatically.
+                Defaults to None -> str(uuid.uuid4()).
+            default_work_amount (float, optional):
+                Basic parameter.
+                Default workamount of this BaseTask.
+                Defaults to None -> 10.0.
+            work_amount_progress_of_unit_step_time (float, optional)
+                Baseline of work amount progress of unit step time.
+                Default to None -> 1.0.
+            input_task_id_dependency_set (set(tuple(str, BaseTaskDependency)), optional):
+                Basic parameter.
+                Set of input BaseTask id and type of dependency(FS, SS, SF, F/F) tuple.
+                Defaults to None -> set().
+            allocated_team_id_set (set(str), optional):
+                Basic parameter.
+                Set of allocated BaseTeam id.
+                Defaults to None -> set().
+            allocated_workplace_id_set (set(str), optional):
+                Basic parameter.
+                Set of allocated BaseWorkplace id.
+                Defaults to None -> set().
+            parent_workflow_id (str, optional):
+                Basic parameter.
+                Parent workflow id.
+                Defaults to None.
+            workplace_priority_rule (WorkplacePriorityRuleMode, optional):
+                Workplace priority rule for simulation.
+                Defaults to WorkplacePriorityRuleMode.FSS.
+            worker_priority_rule (ResourcePriorityRule, optional):
+                Worker priority rule for simulation.
+                Defaults to ResourcePriorityRule.SSP.
+            facility_priority_rule (ResourcePriorityRule, optional):
+                Task priority rule for simulation.
+                Defaults to TaskPriorityRule.TSLACK.
+            need_facility (bool, optional):
+                Basic parameter.
+                Whether one facility is needed for performing this task or not.
+                Defaults to False
+            target_component_id (str, optional):
+                Basic parameter.
+                Target BaseComponent id.
+                Defaults to None.
+            default_progress (float, optional):
+                Basic parameter.
+                Progress before starting simulation (0.0 ~ 1.0)
+                Defaults to None -> 0.0.
+            due_time (int, optional):
+                Basic parameter.
+                Defaults to None -> int(-1).
+            auto_task (bool, optional):
+                Basic parameter.
+                If True, this task is performed automatically
+                even if there are no allocated workers.
+                Defaults to False.
+            fixing_allocating_worker_id_set (set(str), optional):
+                Basic parameter.
+                Allocating worker ID set for fixing allocation in simulation.
+                Defaults to None.
+            fixing_allocating_facility_id_set (set(str), optional):
+                Basic parameter.
+                Allocating facility ID set for fixing allocation in simulation.
+                Defaults to None.
+            est (float, optional):
+                Basic variable.
+                Earliest start time of CPM. This will be updated step by step.
+                Defaults to 0.0.
+            eft (float, optional):
+                Basic variable.
+                Earliest finish time of CPM. This will be updated step by step.
+                Defaults to 0.0.
+            lst (float, optional):
+                Basic variable.
+                Latest start time of CPM. This will be updated step by step.
+                Defaults to -1.0.
+            lft (float, optional):
+                Basic variable.
+                Latest finish time of CPM. This will be updated step by step.
+                Defaults to -1.0.
+            remaining_work_amount (float, optional):
+                Basic variable.
+                Remaining workamount in simulation.
+                Defaults to None -> default_work_amount * (1.0 - default_progress).
+            remaining_work_amount_record_list (List[float], optional):
+                Basic variable.
+                Record of remaining workamount in simulation.
+                Defaults to None -> [].
+            state (BaseTaskState, optional):
+                Basic variable.
+                State of this task in simulation.
+                Defaults to BaseTaskState.NONE.
+            state_record_list (List[BaseTaskState], optional):
+                Basic variable.
+                Record list of state.
+                Defaults to None -> [].
+            allocated_worker_facility_id_tuple_set (set(tuple(str, str)), optional):
+                Basic variable.
+                State of allocating worker and facility id tuple set in simulation.
+                Defaults to None -> set().
+            allocated_worker_facility_id_tuple_set_record_list (List[set[tuple(str, str)]], optional):
+                Basic variable.
+                State of allocating worker and facility id tuple set in simulation.
+                Defaults to None -> [].
+            additional_work_amount (float, optional):
+                Advanced parameter.
+                Defaults to None.
+            additional_task_flag (bool, optional):
+                Advanced variable.
+                Defaults to False.
+            actual_work_amount (float, optional):
+                Advanced variable.
+                Default to None -> default_work_amount*(1.0-default_progress)
+        """
+        task = BaseTask(
+            name=name,
+            ID=ID,
+            default_work_amount=default_work_amount,
+            work_amount_progress_of_unit_step_time=work_amount_progress_of_unit_step_time,
+            input_task_id_dependency_set=input_task_id_dependency_set,
+            allocated_team_id_set=allocated_team_id_set,
+            allocated_workplace_id_set=allocated_workplace_id_set,
+            parent_workflow_id=parent_workflow_id,
+            workplace_priority_rule=workplace_priority_rule,
+            worker_priority_rule=worker_priority_rule,
+            facility_priority_rule=facility_priority_rule,
+            need_facility=need_facility,
+            target_component_id=target_component_id if target_component_id else self.ID,
+            default_progress=default_progress,
+            due_time=due_time,
+            auto_task=auto_task,
+            fixing_allocating_worker_id_set=fixing_allocating_worker_id_set,
+            fixing_allocating_facility_id_set=fixing_allocating_facility_id_set,
+            # Basic variables
+            est=est,
+            eft=eft,
+            lst=lst,
+            lft=lft,
+            remaining_work_amount=remaining_work_amount,
+            remaining_work_amount_record_list=remaining_work_amount_record_list,
+            state=state,
+            state_record_list=state_record_list,
+            allocated_worker_facility_id_tuple_set=allocated_worker_facility_id_tuple_set,
+            allocated_worker_facility_id_tuple_set_record_list=allocated_worker_facility_id_tuple_set_record_list,
+            # Advanced parameters for customized simulation
+            additional_work_amount=additional_work_amount,
+            # Advanced variables for customized simulation
+            additional_task_flag=additional_task_flag,
+            actual_work_amount=actual_work_amount,
+        )
+        self.add_targeted_task(task)
+        return task
 
     def initialize(self, state_info=True, log_info=True):
         """

--- a/pDESy/model/base_component.py
+++ b/pDESy/model/base_component.py
@@ -298,7 +298,6 @@ class BaseComponent(object, metaclass=abc.ABCMeta):
         worker_priority_rule=ResourcePriorityRuleMode.MW,
         facility_priority_rule=ResourcePriorityRuleMode.SSP,
         need_facility=False,
-        target_component_id=None,
         default_progress=None,
         due_time=None,
         auto_task=False,
@@ -368,10 +367,6 @@ class BaseComponent(object, metaclass=abc.ABCMeta):
                 Basic parameter.
                 Whether one facility is needed for performing this task or not.
                 Defaults to False
-            target_component_id (str, optional):
-                Basic parameter.
-                Target BaseComponent id.
-                Defaults to None.
             default_progress (float, optional):
                 Basic parameter.
                 Progress before starting simulation (0.0 ~ 1.0)
@@ -455,7 +450,6 @@ class BaseComponent(object, metaclass=abc.ABCMeta):
             worker_priority_rule=worker_priority_rule,
             facility_priority_rule=facility_priority_rule,
             need_facility=need_facility,
-            target_component_id=target_component_id if target_component_id else self.ID,
             default_progress=default_progress,
             due_time=due_time,
             auto_task=auto_task,

--- a/pDESy/model/base_product.py
+++ b/pDESy/model/base_product.py
@@ -121,6 +121,84 @@ class BaseProduct(object, metaclass=abc.ABCMeta):
         for component in component_set:
             self.add_component(component)
 
+    def create_component(
+        self,
+        # Basic parameters
+        name=None,
+        ID=None,
+        child_component_id_set=None,
+        targeted_task_id_set=None,
+        space_size=None,
+        # Basic variables
+        state=BaseComponentState.NONE,
+        state_record_list=None,
+        placed_workplace_id=None,
+        placed_workplace_id_record_list=None,
+        # Advanced parameters for customized simulation
+        error_tolerance=None,
+        # Advanced variables for customized simulation
+        error=None,
+    ):
+        """
+        Create BaseComponent instance and add it to this product.
+
+        Args:
+            name (str, optional):
+                Basic parameter.
+                Name of this component.
+                Defaults to None -> "New Component"
+            ID (str, optional):
+                Basic parameter.
+                ID will be defined automatically.
+            child_component_id_set (set(str), optional):
+                Basic parameter.
+                Child BaseComponents id set.
+                Defaults to None -> set().
+            targeted_task_id_set (set(str), optional):
+                Basic parameter.
+                Targeted tasks id set.
+                Defaults to None -> set().
+            space_size (float, optional):
+                Basic parameter.
+                Space size related to base_workplace's max_space_size.
+                Default to None -> 1.0.
+            state (BaseComponentState, optional):
+                Basic variable.
+                State of this task in simulation.
+                Defaults to BaseComponentState.NONE.
+            state_record_list (List[BaseComponentState], optional):
+                Basic variable.
+                Record list of state.
+                Defaults to None -> [].
+            placed_workplace_id (str, optional):
+                Basic variable.
+                A workplace which this component is placed in simulation.
+                Defaults to None.
+            placed_workplace_id_record_list (List[str], optional):
+                Basic variable.
+                Record of placed workplace ID in simulation.
+                Defaults to None -> [].
+            error_tolerance (float, optional):
+                Advanced parameter.
+            error (float, optional):
+                Advanced variables.
+        """
+        component = BaseComponent(
+            name=name,
+            ID=ID,
+            child_component_id_set=child_component_id_set,
+            targeted_task_id_set=targeted_task_id_set,
+            space_size=space_size,
+            state=state,
+            state_record_list=state_record_list,
+            placed_workplace_id=placed_workplace_id,
+            placed_workplace_id_record_list=placed_workplace_id_record_list,
+            error_tolerance=error_tolerance,
+            error=error,
+        )
+        self.add_component(component)
+        return component
+
     def export_dict_json_data(self):
         """
         Export the information of this product to JSON data.

--- a/pDESy/model/base_team.py
+++ b/pDESy/model/base_team.py
@@ -179,6 +179,121 @@ class BaseTeam(object, metaclass=abc.ABCMeta):
         worker.team_id = self.ID
         self.worker_set.add(worker)
 
+    def create_worker(
+        self,
+        # Basic parameters
+        name=None,
+        ID=None,
+        main_workplace_id=None,
+        cost_per_time=0.0,
+        solo_working=False,
+        workamount_skill_mean_map=None,
+        workamount_skill_sd_map=None,
+        facility_skill_map=None,
+        absence_time_list=None,
+        # Basic variables
+        state=BaseWorkerState.FREE,
+        state_record_list=None,
+        cost_record_list=None,
+        assigned_task_facility_id_tuple_set=None,
+        assigned_task_facility_id_tuple_set_record_list=None,
+        # Advanced parameters for customized simulation
+        quality_skill_mean_map=None,
+        quality_skill_sd_map=None,
+    ):
+        """
+        Create a BaseWorker instance and add it to this team.
+
+        Args:
+            name (str, optional):
+                Basic parameter.
+                Name of this worker.
+                Defaults to None -> "New Worker"
+            ID (str, optional):
+                Basic parameter.
+                ID will be defined automatically.
+                Defaults to None -> str(uuid.uuid4()).
+            main_workplace_id (str, optional):
+                Basic parameter.
+                Defaults to None.
+            cost_per_time (float, optional):
+                Basic parameter.
+                Cost of this worker per unit time.
+                Defaults to 0.0.
+            solo_working (bool, optional):
+                Basic parameter.
+                Flag whether this worker can work with other workers or not.
+                Defaults to False.
+            workamount_skill_mean_map (Dict[str, float], optional):
+                Basic parameter.
+                Skill for expressing progress in unit time.
+                Defaults to None -> {}.
+            workamount_skill_sd_map (Dict[str, float], optional):
+                Basic parameter.
+                Standard deviation of skill for expressing progress in unit time.
+                Defaults to None -> {}.
+            facility_skill_map (Dict[str, float], optional):
+                Basic parameter.
+                Skill for operating facility in unit time.
+                Defaults to None -> {}.
+            absence_time_list (List[int], optional):
+                List of absence time of simulation.
+                Defaults to None -> [].
+            state (BaseWorkerState, optional):
+                Basic variable.
+                State of this worker in simulation.
+                Defaults to BaseWorkerState.FREE.
+            state_record_list (List[BaseWorkerState], optional):
+                Basic variable.
+                Record list of state.
+                Defaults to None -> [].
+            cost_record_list (List[float], optional):
+                Basic variable.
+                History or record of his or her cost in simulation.
+                Defaults to None -> [].
+            assigned_task_facility_id_tuple_set (set(tuple(str, str)), optional):
+                Basic variable.
+                State of his or her assigned task and facility id tuple in simulation.
+                Defaults to None -> set().
+            assigned_task_facility_id_tuple_set_record_list (List[set(tuple(str, str))], optional):
+                Basic variable.
+                Record of his or her assigned tasks' id in simulation.
+                Defaults to None -> [].
+            quality_skill_mean_map (Dict[str, float], optional):
+                Advanced parameter.
+                Skill for expressing quality in unit time.
+                Defaults to None -> {}.
+            quality_skill_sd_map (Dict[str, float], optional):
+                Advanced parameter.
+                Standard deviation of skill for expressing quality in unit time.
+                Defaults to None -> {}.
+        """
+        worker = BaseWorker(
+            # Basic parameters
+            name=name,
+            ID=ID,
+            main_workplace_id=main_workplace_id,
+            cost_per_time=cost_per_time,
+            solo_working=solo_working,
+            workamount_skill_mean_map=workamount_skill_mean_map,
+            workamount_skill_sd_map=workamount_skill_sd_map,
+            facility_skill_map=facility_skill_map,
+            absence_time_list=absence_time_list,
+            # Basic variables
+            state=state,
+            state_record_list=state_record_list,
+            cost_record_list=cost_record_list,
+            assigned_task_facility_id_tuple_set=assigned_task_facility_id_tuple_set,
+            assigned_task_facility_id_tuple_set_record_list=(
+                assigned_task_facility_id_tuple_set_record_list
+            ),
+            # Advanced parameters for customized simulation
+            quality_skill_mean_map=quality_skill_mean_map,
+            quality_skill_sd_map=quality_skill_sd_map,
+        )
+        self.add_worker(worker)
+        return worker
+
     def initialize(self, state_info=True, log_info=True):
         """
         Initialize the following changeable variables of BaseTeam.

--- a/pDESy/model/base_workflow.py
+++ b/pDESy/model/base_workflow.py
@@ -15,6 +15,11 @@ import networkx as nx
 import plotly.figure_factory as ff
 import plotly.graph_objects as go
 
+from pDESy.model.base_priority_rule import (
+    ResourcePriorityRuleMode,
+    WorkplacePriorityRuleMode,
+)
+
 from .base_task import BaseTask, BaseTaskDependency, BaseTaskState
 from .base_subproject_task import BaseSubProjectTask
 
@@ -125,6 +130,202 @@ class BaseWorkflow(object, metaclass=abc.ABCMeta):
         """
         for task in task_set:
             self.add_task(task)
+
+    def create_task(
+        self,
+        name=None,
+        ID=None,
+        default_work_amount=None,
+        work_amount_progress_of_unit_step_time=None,
+        input_task_id_dependency_set=None,
+        allocated_team_id_set=None,
+        allocated_workplace_id_set=None,
+        workplace_priority_rule=WorkplacePriorityRuleMode.FSS,
+        worker_priority_rule=ResourcePriorityRuleMode.MW,
+        facility_priority_rule=ResourcePriorityRuleMode.SSP,
+        need_facility=False,
+        target_component_id=None,
+        default_progress=None,
+        due_time=None,
+        auto_task=False,
+        fixing_allocating_worker_id_set=None,
+        fixing_allocating_facility_id_set=None,
+        # Basic variables
+        est=0.0,
+        eft=0.0,
+        lst=-1.0,
+        lft=-1.0,
+        remaining_work_amount=None,
+        remaining_work_amount_record_list=None,
+        state=BaseTaskState.NONE,
+        state_record_list=None,
+        allocated_worker_facility_id_tuple_set=None,
+        allocated_worker_facility_id_tuple_set_record_list=None,
+        # Advanced parameters for customized simulation
+        additional_work_amount=None,
+        # Advanced variables for customized simulation
+        additional_task_flag=False,
+        actual_work_amount=None,
+    ):
+        """
+        Create a BaseTask instance and add it to this workflow.
+
+        Args:
+            name (str, optional):
+                Basic parameter.
+                Name of this task.
+                Defaults to None -> "New Task".
+            ID (str, optional):
+                Basic parameter.
+                ID will be defined automatically.
+                Defaults to None -> str(uuid.uuid4()).
+            default_work_amount (float, optional):
+                Basic parameter.
+                Default workamount of this BaseTask.
+                Defaults to None -> 10.0.
+            work_amount_progress_of_unit_step_time (float, optional)
+                Baseline of work amount progress of unit step time.
+                Default to None -> 1.0.
+            input_task_id_dependency_set (set(tuple(str, BaseTaskDependency)), optional):
+                Basic parameter.
+                Set of input BaseTask id and type of dependency(FS, SS, SF, F/F) tuple.
+                Defaults to None -> set().
+            allocated_team_id_set (set(str), optional):
+                Basic parameter.
+                Set of allocated BaseTeam id.
+                Defaults to None -> set().
+            allocated_workplace_id_set (set(str), optional):
+                Basic parameter.
+                Set of allocated BaseWorkplace id.
+                Defaults to None -> set().
+            parent_workflow_id (str, optional):
+                Basic parameter.
+                Parent workflow id.
+                Defaults to None.
+            workplace_priority_rule (WorkplacePriorityRuleMode, optional):
+                Workplace priority rule for simulation.
+                Defaults to WorkplacePriorityRuleMode.FSS.
+            worker_priority_rule (ResourcePriorityRule, optional):
+                Worker priority rule for simulation.
+                Defaults to ResourcePriorityRule.SSP.
+            facility_priority_rule (ResourcePriorityRule, optional):
+                Task priority rule for simulation.
+                Defaults to TaskPriorityRule.TSLACK.
+            need_facility (bool, optional):
+                Basic parameter.
+                Whether one facility is needed for performing this task or not.
+                Defaults to False
+            target_component_id (str, optional):
+                Basic parameter.
+                Target BaseComponent id.
+                Defaults to None.
+            default_progress (float, optional):
+                Basic parameter.
+                Progress before starting simulation (0.0 ~ 1.0)
+                Defaults to None -> 0.0.
+            due_time (int, optional):
+                Basic parameter.
+                Defaults to None -> int(-1).
+            auto_task (bool, optional):
+                Basic parameter.
+                If True, this task is performed automatically
+                even if there are no allocated workers.
+                Defaults to False.
+            fixing_allocating_worker_id_set (set(str), optional):
+                Basic parameter.
+                Allocating worker ID set for fixing allocation in simulation.
+                Defaults to None.
+            fixing_allocating_facility_id_set (set(str), optional):
+                Basic parameter.
+                Allocating facility ID set for fixing allocation in simulation.
+                Defaults to None.
+            est (float, optional):
+                Basic variable.
+                Earliest start time of CPM. This will be updated step by step.
+                Defaults to 0.0.
+            eft (float, optional):
+                Basic variable.
+                Earliest finish time of CPM. This will be updated step by step.
+                Defaults to 0.0.
+            lst (float, optional):
+                Basic variable.
+                Latest start time of CPM. This will be updated step by step.
+                Defaults to -1.0.
+            lft (float, optional):
+                Basic variable.
+                Latest finish time of CPM. This will be updated step by step.
+                Defaults to -1.0.
+            remaining_work_amount (float, optional):
+                Basic variable.
+                Remaining workamount in simulation.
+                Defaults to None -> default_work_amount * (1.0 - default_progress).
+            remaining_work_amount_record_list (List[float], optional):
+                Basic variable.
+                Record of remaining workamount in simulation.
+                Defaults to None -> [].
+            state (BaseTaskState, optional):
+                Basic variable.
+                State of this task in simulation.
+                Defaults to BaseTaskState.NONE.
+            state_record_list (List[BaseTaskState], optional):
+                Basic variable.
+                Record list of state.
+                Defaults to None -> [].
+            allocated_worker_facility_id_tuple_set (set(tuple(str, str)), optional):
+                Basic variable.
+                State of allocating worker and facility id tuple set in simulation.
+                Defaults to None -> set().
+            allocated_worker_facility_id_tuple_set_record_list (List[set[tuple(str, str)]], optional):
+                Basic variable.
+                State of allocating worker and facility id tuple set in simulation.
+                Defaults to None -> [].
+            additional_work_amount (float, optional):
+                Advanced parameter.
+                Defaults to None.
+            additional_task_flag (bool, optional):
+                Advanced variable.
+                Defaults to False.
+            actual_work_amount (float, optional):
+                Advanced variable.
+                Default to None -> default_work_amount*(1.0-default_progress)
+        """
+        task = BaseTask(
+            name=name,
+            ID=ID,
+            default_work_amount=default_work_amount,
+            work_amount_progress_of_unit_step_time=work_amount_progress_of_unit_step_time,
+            input_task_id_dependency_set=input_task_id_dependency_set,
+            allocated_team_id_set=allocated_team_id_set,
+            allocated_workplace_id_set=allocated_workplace_id_set,
+            workplace_priority_rule=workplace_priority_rule,
+            worker_priority_rule=worker_priority_rule,
+            facility_priority_rule=facility_priority_rule,
+            need_facility=need_facility,
+            target_component_id=target_component_id,
+            default_progress=default_progress,
+            due_time=due_time,
+            auto_task=auto_task,
+            fixing_allocating_worker_id_set=fixing_allocating_worker_id_set,
+            fixing_allocating_facility_id_set=fixing_allocating_facility_id_set,
+            # Basic variables
+            est=est,
+            eft=eft,
+            lst=lst,
+            lft=lft,
+            remaining_work_amount=remaining_work_amount,
+            remaining_work_amount_record_list=remaining_work_amount_record_list,
+            state=state,
+            state_record_list=state_record_list,
+            allocated_worker_facility_id_tuple_set=allocated_worker_facility_id_tuple_set,
+            allocated_worker_facility_id_tuple_set_record_list=allocated_worker_facility_id_tuple_set_record_list,
+            # Advanced parameters for customized simulation
+            additional_work_amount=additional_work_amount,
+            # Advanced variables for customized simulation
+            additional_task_flag=additional_task_flag,
+            actual_work_amount=actual_work_amount,
+        )
+        self.add_task(task)
+        return task
 
     def export_dict_json_data(self):
         """

--- a/pDESy/model/base_workflow.py
+++ b/pDESy/model/base_workflow.py
@@ -183,7 +183,7 @@ class BaseWorkflow(object, metaclass=abc.ABCMeta):
                 Basic parameter.
                 Default workamount of this BaseTask.
                 Defaults to None -> 10.0.
-            work_amount_progress_of_unit_step_time (float, optional)
+            work_amount_progress_of_unit_step_time (float, optional):
                 Baseline of work amount progress of unit step time.
                 Default to None -> 1.0.
             input_task_id_dependency_set (set(tuple(str, BaseTaskDependency)), optional):
@@ -198,10 +198,6 @@ class BaseWorkflow(object, metaclass=abc.ABCMeta):
                 Basic parameter.
                 Set of allocated BaseWorkplace id.
                 Defaults to None -> set().
-            parent_workflow_id (str, optional):
-                Basic parameter.
-                Parent workflow id.
-                Defaults to None.
             workplace_priority_rule (WorkplacePriorityRuleMode, optional):
                 Workplace priority rule for simulation.
                 Defaults to WorkplacePriorityRuleMode.FSS.

--- a/pDESy/model/base_workplace.py
+++ b/pDESy/model/base_workplace.py
@@ -166,6 +166,95 @@ class BaseWorkplace(object, metaclass=abc.ABCMeta):
         facility.workplace_id = self.ID
         self.facility_set.add(facility)
 
+    def create_facility(
+        self,
+        # Basic parameters
+        name=None,
+        ID=None,
+        cost_per_time=0.0,
+        solo_working=False,
+        workamount_skill_mean_map=None,
+        workamount_skill_sd_map=None,
+        absence_time_list=None,
+        # Basic variables
+        state=BaseFacilityState.FREE,
+        state_record_list=None,
+        cost_record_list=None,
+        assigned_task_worker_id_tuple_set=None,
+        assigned_task_worker_id_tuple_set_record_list=None,
+    ):
+        """
+        Create a new BaseFacility and add it to this workplace.
+
+        Args:
+            name (str, optional):
+                Basic parameter.
+                Name of this facility.
+                Defaults to None -> "New Facility"
+            ID (str, optional):
+                Basic parameter.
+                ID will be defined automatically.
+                Defaults to None -> str(uuid.uuid4()).
+            cost_per_time (float, optional):
+                Basic parameter.
+                Cost of this facility per unit time.
+                Defaults to 0.0.
+            solo_working (bool, optional):
+                Basic parameter.
+                Flag whether this facility can work any task with other facilities or not.
+                Defaults to False.
+            workamount_skill_mean_map (Dict[str, float], optional):
+                Basic parameter.
+                Mean skill for expressing progress in unit time.
+                Defaults to {}.
+            workamount_skill_sd_map (Dict[str, float], optional):
+                Basic parameter.
+                Standard deviation of skill for expressing progress in unit time.
+                Defaults to {}.
+            absence_time_list (List[int], optional):
+                List of absence time of simulation.
+                Defaults to None -> [].
+            state (BaseFacilityState, optional):
+                Basic variable.
+                State of this facility in simulation.
+                Defaults to BaseFacilityState.FREE.
+            state_record_list (List[BaseFacilityState], optional):
+                Basic variable.
+                Record list of state.
+                Defaults to None -> [].
+            cost_record_list (List[float], optional):
+                Basic variable.
+                History or record of his or her cost in simulation.
+                Defaults to None -> [].
+            assigned_task_worker_id_tuple_set (set(tuple(str, str)), optional):
+                Basic variable.
+                State of his or her assigned tasks id in simulation.
+                Defaults to None -> set().
+            assigned_task_worker_id_tuple_set_record_list (List[set(tuple(str, str))], optional):
+                Basic variable.
+                Record of his or her assigned tasks' id in simulation.
+                Defaults to None -> [].
+        """
+        facility = BaseFacility(
+            # Basic parameters
+            name=name,
+            ID=ID,
+            workplace_id=self.ID,
+            cost_per_time=cost_per_time,
+            solo_working=solo_working,
+            workamount_skill_mean_map=workamount_skill_mean_map,
+            workamount_skill_sd_map=workamount_skill_sd_map,
+            absence_time_list=absence_time_list,
+            # Basic variables
+            state=state,
+            state_record_list=state_record_list,
+            cost_record_list=cost_record_list,
+            assigned_task_worker_id_tuple_set=assigned_task_worker_id_tuple_set,
+            assigned_task_worker_id_tuple_set_record_list=assigned_task_worker_id_tuple_set_record_list,
+        )
+        self.add_facility(facility)
+        return facility
+
     def get_total_workamount_skill(self, task_name, error_tol=1e-10):
         """
         Get total number of workamount skill of all facilities.

--- a/tests/model/test_base_component.py
+++ b/tests/model/test_base_component.py
@@ -92,6 +92,16 @@ def test_add_targeted_task():
     assert task.target_component_id == c.ID
 
 
+def test_create_task():
+    """test_create_task."""
+    c = BaseComponent("c")
+    task = c.create_task(name="task1")
+    assert isinstance(task, BaseTask)
+    assert task.name == "task1"
+    assert task.target_component_id == c.ID
+    assert c.targeted_task_id_set == {task.ID}
+
+
 def test_initialize():
     """test_initialize."""
     c = BaseComponent("c", error_tolerance=0.1)

--- a/tests/model/test_base_product.py
+++ b/tests/model/test_base_product.py
@@ -26,6 +26,14 @@ def test_initialize():
     product.initialize()
 
 
+def test_create_component():
+    """test_create_component."""
+    product = BaseProduct()
+    component = product.create_component("c1")
+    assert component in product.component_set
+    assert component.parent_product_id == product.ID
+
+
 def test_str():
     """test_str."""
     print(BaseProduct(component_set=set()))

--- a/tests/model/test_base_team.py
+++ b/tests/model/test_base_team.py
@@ -79,6 +79,21 @@ def test_add_worker():
     assert worker.team_id == team.ID
 
 
+def test_create_worker():
+    """test_create_worker."""
+    team = BaseTeam("team")
+    worker1 = team.create_worker(
+        name="worker1",
+    )
+    assert worker1.name == "worker1"
+    assert worker1.team_id == team.ID
+    assert team.worker_set == {worker1}
+    worker2 = team.create_worker(
+        name="worker2",
+    )
+    assert team.worker_set == {worker2, worker1}
+
+
 def test_initialize():
     """test_initialize."""
     team = BaseTeam("team")
@@ -305,12 +320,7 @@ def test_create_data_for_cost_history_plotly():
 
     init_datetime = datetime.datetime(2020, 4, 1, 8, 0, 0)
     timedelta = datetime.timedelta(days=1)
-    data = team.create_data_for_cost_history_plotly(init_datetime, timedelta)
-
-    x = [
-        (init_datetime + time * timedelta).strftime("%Y-%m-%d %H:%M:%S")
-        for time in range(len(team.cost_record_list))
-    ]
+    team.create_data_for_cost_history_plotly(init_datetime, timedelta)
 
 
 def test_create_cost_history_plotly(tmpdir):

--- a/tests/model/test_base_workflow.py
+++ b/tests/model/test_base_workflow.py
@@ -144,6 +144,15 @@ def test_str():
     print(BaseWorkflow(task_set=set()))
 
 
+def test_create_task():
+    """test_create_task."""
+    w = BaseWorkflow()
+    task = w.create_task(name="task1")
+    assert task.name == "task1"
+    assert w.task_set == {task}
+    assert task.parent_workflow_id == w.ID
+
+
 @pytest.fixture(name="dummy_workflow_for_extracting")
 def fixture_dummy_workflow_for_extracting():
     """dummy_workflow_for_extracting."""

--- a/tests/model/test_base_workplace.py
+++ b/tests/model/test_base_workplace.py
@@ -149,6 +149,22 @@ def test_add_targeted_task():
     assert task2.allocated_workplace_id_set == {workplace.ID}
 
 
+def test_create_facility():
+    """test_create_facility."""
+    workplace = BaseWorkplace("workplace")
+    facility1 = workplace.create_facility(
+        name="facility1",
+    )
+    assert facility1.name == "facility1"
+    assert facility1.workplace_id == workplace.ID
+    assert workplace.facility_set == {facility1}
+    facility2 = workplace.create_facility(
+        name="facility2",
+    )
+    assert facility2.workplace_id == workplace.ID
+    assert workplace.facility_set == {facility2, facility1}
+
+
 def test_initialize():
     """test_initialize."""
     workplace = BaseWorkplace("workplace")


### PR DESCRIPTION
This pull request introduces new convenience methods for creating and adding core simulation objects (`BaseTask`, `BaseComponent`, and `BaseWorker`) directly to their respective parent objects, streamlining object instantiation and association in the codebase. These methods provide a more user-friendly API for constructing simulation models and ensure that new instances are properly added to their containers.

**Core API Enhancements**

* Added `create_task` method to `BaseComponent`, allowing for the creation and automatic addition of a `BaseTask` to the component's targeted tasks. This method includes comprehensive parameter documentation for flexible task instantiation.
* Added `create_component` method to `BaseProduct`, enabling the creation and addition of a `BaseComponent` to the product, with detailed parameter documentation for customization.
* Added `create_worker` method to `BaseTeam`, facilitating the creation and association of a `BaseWorker` with the team, along with extensive parameter documentation.

**Imports and Dependency Updates**

* Updated imports in `base_component.py` and `base_workflow.py` to include `ResourcePriorityRuleMode` and `WorkplacePriorityRuleMode` from `base_priority_rule`, supporting the new methods and ensuring correct type references. [[1]](diffhunk://#diff-b1ce0f3d9b4e1880ea43b7ba55fd05d267c5e3e313593fad58d2ba62bb4eda4eL13-R17) [[2]](diffhunk://#diff-629942b419da5b21b636b8368cff5ec5aa29aa0f5a3535527103d983a7d0cd07R18-R22)