### PR TITLE
add create_product, create_workflow, create_team, create_workplace

### DIFF
--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -333,6 +333,24 @@ class BaseProject(object, metaclass=ABCMeta):
             raise TypeError("All items in workplace_set should be BaseWorkplace")
         self.workplace_set.update(workplace_set)
 
+    def create_product(
+        self, name: str = None, ID: str = None, component_set: set[BaseComponent] = None
+    ):
+        """
+        Create a new product and add it to the project.
+
+        Args:
+            name (str, optional): Name of the product.
+            ID (str, optional): ID of the product.
+            component_set (set[BaseComponent], optional): Set of components to include in the product.
+
+        Returns:
+            BaseProduct: The created product.
+        """
+        product = BaseProduct(name=name, ID=ID, component_set=component_set)
+        self.add_product(product)
+        return product
+
     def add_product(self, product: BaseProduct):
         """
         Add product to this project.
@@ -360,6 +378,35 @@ class BaseProject(object, metaclass=ABCMeta):
         if not all(isinstance(product, BaseProduct) for product in product_set):
             raise TypeError("All items in product_set should be BaseProduct")
         self.product_set.update(product_set)
+
+    def create_workflow(
+        self,
+        name: str = None,
+        ID: str = None,
+        task_set: set[BaseTask] = None,
+        # Basic variables
+        critical_path_length: float = 0.0,
+    ):
+        """
+        Create a new workflow and add it to the project.
+
+        Args:
+            name (str, optional): Name of this workflow. Defaults to None -> "Workflow".
+            ID (str, optional): ID will be defined automatically. Defaults to None -> str(uuid.uuid4()).
+            task_set (set[BaseTask], optional): List of BaseTask in this BaseWorkflow. Default to None -> set().
+            critical_path_length (float, optional): Critical path length of PERT/CPM. Defaults to 0.0.
+
+        Returns:
+            BaseWorkflow: The created workflow.
+        """
+        workflow = BaseWorkflow(
+            name=name,
+            ID=ID,
+            task_set=task_set,
+            critical_path_length=critical_path_length,
+        )
+        self.add_workflow(workflow)
+        return workflow
 
     def add_workflow(self, workflow: BaseWorkflow):
         """
@@ -389,6 +436,40 @@ class BaseProject(object, metaclass=ABCMeta):
             raise TypeError("All items in workflow_set should be BaseWorkflow")
         self.workflow_set.update(workflow_set)
 
+    def create_team(
+        self,
+        name: str = None,
+        ID: str = None,
+        worker_set: set[BaseWorker] = None,
+        targeted_task_id_set: set[str] = None,
+        parent_team_id: str = None,
+        cost_record_list: list[float] = None,
+    ):
+        """
+        Create a new team and add it to the project.
+
+        Args:
+            name (str, optional): Name of this team. Defaults to None -> "New Team".
+            ID (str, optional): ID will be defined automatically. Defaults to None -> str(uuid.uuid4()).
+            worker_set (set[BaseWorker], optional): Set of BaseWorkers who belong to this team. Defaults to None -> set().
+            targeted_task_id_set (set[str], optional): Targeted BaseTasks id set. Defaults to None -> set().
+            parent_team_id (str, optional): Parent team id of this team. Defaults to None.
+            cost_record_list (List[float], optional): History or record of this team's cost in simulation. Defaults to None -> [].
+
+        Returns:
+            BaseTeam: The created team.
+        """
+        team = BaseTeam(
+            name=name,
+            ID=ID,
+            worker_set=worker_set,
+            targeted_task_id_set=targeted_task_id_set,
+            parent_team_id=parent_team_id,
+            cost_record_list=cost_record_list,
+        )
+        self.add_team(team)
+        return team
+
     def add_team(self, team: BaseTeam):
         """
         Add team to this project.
@@ -416,6 +497,56 @@ class BaseProject(object, metaclass=ABCMeta):
         if not all(isinstance(team, BaseTeam) for team in team_set):
             raise TypeError("All items in team_set should be BaseTeam")
         self.team_set.update(team_set)
+
+    def create_workplace(
+        self,
+        name: str = None,
+        ID: str = None,
+        facility_set: set[BaseFacility] = None,
+        targeted_task_id_set: set[str] = None,
+        parent_workplace_id: str = None,
+        max_space_size: float = None,
+        input_workplace_id_set: set[str] = None,
+        # Basic variables
+        available_space_size: float = None,
+        cost_record_list: list[float] = None,
+        placed_component_id_set: set[str] = None,
+        placed_component_id_set_record_list: list[list[str]] = None,
+    ):
+        """
+        Create a new workplace and add it to the project.
+
+        Args:
+            name (str, optional): Name of this workplace. Defaults to None -> "New Workplace".
+            ID (str, optional): ID will be defined automatically. Defaults to None -> str(uuid.uuid4()).
+            facility_set (set[BaseFacility], optional): List of BaseFacility who belong to this workplace. Defaults to None -> set().
+            targeted_task_id_set (set[str], optional): Targeted BaseTasks id set. Defaults to None -> set().
+            parent_workplace_id (str, optional): Parent workplace id of this workplace. Defaults to None.
+            max_space_size (float, optional): Max size of space for placing components. Default to None -> 1.0.
+            input_workplace_id_set (set[str], optional): Input BaseWorkplace id set. Defaults to None -> set().
+            available_space_size (float, optional): Available space size in this workplace. Defaults to None -> max_space_size.
+            placed_component_id_set (set[str], optional): Components id which places to this workplace in simulation. Defaults to None -> set().
+            placed_component_id_set_record_list (List[List[str]], optional): Record of placed components ID in simulation. Defaults to None -> [].
+        cost_rec    ord_list (List[float], optional): History or record of this workplace's cost in simulation. Defaults to None -> [].
+
+        Returns:
+            BaseWorkplace: The created workplace.
+        """
+        workplace = BaseWorkplace(
+            name=name,
+            ID=ID,
+            facility_set=facility_set,
+            targeted_task_id_set=targeted_task_id_set,
+            parent_workplace_id=parent_workplace_id,
+            max_space_size=max_space_size,
+            input_workplace_id_set=input_workplace_id_set,
+            available_space_size=available_space_size,
+            placed_component_id_set=placed_component_id_set,
+            placed_component_id_set_record_list=placed_component_id_set_record_list,
+            cost_record_list=cost_record_list,
+        )
+        self.add_workplace(workplace)
+        return workplace
 
     def add_workplace(self, workplace: BaseWorkplace):
         """

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -527,7 +527,7 @@ class BaseProject(object, metaclass=ABCMeta):
             available_space_size (float, optional): Available space size in this workplace. Defaults to None -> max_space_size.
             placed_component_id_set (set[str], optional): Components id which places to this workplace in simulation. Defaults to None -> set().
             placed_component_id_set_record_list (List[List[str]], optional): Record of placed components ID in simulation. Defaults to None -> [].
-        cost_rec    ord_list (List[float], optional): History or record of this workplace's cost in simulation. Defaults to None -> [].
+        cost_record_list (List[float], optional): History or record of this workplace's cost in simulation. Defaults to None -> [].
 
         Returns:
             BaseWorkplace: The created workplace.

--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -527,7 +527,7 @@ class BaseProject(object, metaclass=ABCMeta):
             available_space_size (float, optional): Available space size in this workplace. Defaults to None -> max_space_size.
             placed_component_id_set (set[str], optional): Components id which places to this workplace in simulation. Defaults to None -> set().
             placed_component_id_set_record_list (List[List[str]], optional): Record of placed components ID in simulation. Defaults to None -> [].
-        cost_record_list (List[float], optional): History or record of this workplace's cost in simulation. Defaults to None -> [].
+            cost_record_list (List[float], optional): History or record of this workplace's cost in simulation. Defaults to None -> [].
 
         Returns:
             BaseWorkplace: The created workplace.

--- a/pDESy/model/base_task.py
+++ b/pDESy/model/base_task.py
@@ -9,7 +9,12 @@ import uuid
 from enum import IntEnum
 import warnings
 
+from typing import TYPE_CHECKING
+
 from .base_priority_rule import ResourcePriorityRuleMode, WorkplacePriorityRuleMode
+
+if TYPE_CHECKING:
+    from pDESy.model.base_component import BaseComponent
 
 
 class BaseTaskState(IntEnum):
@@ -298,6 +303,16 @@ class BaseTask(object, metaclass=abc.ABCMeta):
             ],
         )
         return dict_json_data
+
+    def add_target_component(self, target_component: BaseComponent):
+        """
+        Add target component to this task.
+
+        Args:
+            target_component (BaseComponent): Target BaseComponent.
+        """
+        self.target_component_id = target_component.ID
+        target_component.targeted_task_id_set.add(self.ID)
 
     def append_input_task_dependency(
         self,

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -167,7 +167,7 @@ def fixture_dummy_project_multiple():
     workplace1.update_targeted_task_set({task1_1_1, task1_1_2, task1_2_1, task1_3})
 
     workplace2 = project.create_workplace("workplace2")
-    f2 = workplace1.create_facility("f2")
+    f2 = workplace2.create_facility("f2")
     f2.workamount_skill_mean_map = {
         task1_1_1.name: 1.0,
         task2_1_1.name: 1.0,  # same name as task1_1_1, so this is ignored.

--- a/tests/model/test_base_project.py
+++ b/tests/model/test_base_project.py
@@ -116,76 +116,68 @@ def fixture_dummy_project_multiple():
     )
 
     # BaseComponent in BaseProducts
-    c13 = BaseComponent("c3")
-    c11 = BaseComponent("c1")
-    c12 = BaseComponent("c2")
+    p1 = project.create_product("product 1")
+    c11 = p1.create_component("c11")
+    c12 = p1.create_component("c12")
+    c13 = p1.create_component("c13")
     c13.update_child_component_set({c11, c12})
-    p1 = BaseProduct(name="product 1", component_set={c11, c12, c13})
 
-    c23 = BaseComponent("c3")
-    c21 = BaseComponent("c1")
-    c22 = BaseComponent("c2")
+    p2 = project.create_product("product 2")
+    c21 = p2.create_component("c21")
+    c22 = p2.create_component("c22")
+    c23 = p2.create_component("c23")
     c23.update_child_component_set({c21, c22})
-    p2 = BaseProduct(name="product2", component_set={c21, c22, c23})
-
-    project.update_product_set({p1, p2})
 
     # BaseTask in BaseWorkflows
-    task1_1_1 = BaseTask("task1_1", need_facility=True)
-    task1_1_2 = BaseTask("task1_2")
-    task1_2_1 = BaseTask("task2_1")
-    task1_3 = BaseTask("task3", due_time=30)
+    w1 = project.create_workflow("workflow 1")
+    task1_1_1 = w1.create_task("task1_1", need_facility=True)
+    task1_1_1.add_target_component(c11)
+    task1_1_2 = w1.create_task("task1_2")
+    task1_1_2.add_target_component(c11)
+    task1_2_1 = w1.create_task("task2_1")
+    task1_2_1.add_target_component(c12)
+    task1_3 = w1.create_task("task3", due_time=30)
+    task1_3.add_target_component(c13)
     task1_3.add_input_task(task1_1_2)
     task1_3.add_input_task(task1_2_1)
     task1_1_2.add_input_task(task1_1_1)
-    task1_0 = BaseTask("auto", auto_task=True, due_time=20)
-    w1 = BaseWorkflow(
-        name="workflow 1", task_set={task1_1_1, task1_1_2, task1_2_1, task1_3, task1_0}
-    )
-    c11.update_targeted_task_set({task1_1_1, task1_1_2})
-    c12.add_targeted_task(task1_2_1)
-    c13.add_targeted_task(task1_3)
+    _ = w1.create_task("auto", auto_task=True, due_time=20)
 
-    task2_1_1 = BaseTask("task1_1", need_facility=True)
-    task2_1_2 = BaseTask("task1_2")
-    task2_2_1 = BaseTask("task2_1")
-    task2_3 = BaseTask("task3", due_time=30)
+    w2 = project.create_workflow("workflow 2")
+    task2_1_1 = w2.create_task("task1_1", need_facility=True)
+    task2_1_1.add_target_component(c21)
+    task2_1_2 = w2.create_task("task1_2")
+    task2_1_2.add_target_component(c21)
+    task2_2_1 = w2.create_task("task2_1")
+    task2_2_1.add_target_component(c22)
+    task2_3 = w2.create_task("task3", due_time=30)
+    task2_3.add_target_component(c23)
     task2_3.add_input_task(task2_1_2)
     task2_3.add_input_task(task2_2_1)
     task2_1_2.add_input_task(task2_1_1)
-    task2_0 = BaseTask("auto", auto_task=True, due_time=20)
-    w2 = BaseWorkflow(
-        name="workflow 2", task_set={task2_1_1, task2_1_2, task2_2_1, task2_3, task2_0}
-    )
-    c21.update_targeted_task_set({task2_1_1, task2_1_2})
-    c22.add_targeted_task(task2_2_1)
-    c23.add_targeted_task(task2_3)
-
-    project.update_workflow_set({w1, w2})
+    _ = w2.create_task("auto", auto_task=True, due_time=20)
 
     # Facilities in workplace
-    f1 = BaseFacility("f1")
+    workplace1 = project.create_workplace("workplace1")
+    f1 = workplace1.create_facility("f1")
     f1.workamount_skill_mean_map = {
         task1_1_1.name: 1.0,
         task2_1_1.name: 1.0,  # same name as task1_1_1, so this is ignored.
     }
-    workplace1 = BaseWorkplace("workplace1", facility_set={f1})
     workplace1.update_targeted_task_set({task1_1_1, task1_1_2, task1_2_1, task1_3})
 
-    f2 = BaseFacility("f2")
+    workplace2 = project.create_workplace("workplace2")
+    f2 = workplace1.create_facility("f2")
     f2.workamount_skill_mean_map = {
         task1_1_1.name: 1.0,
         task2_1_1.name: 1.0,  # same name as task1_1_1, so this is ignored.
     }
-    workplace2 = BaseWorkplace("workplace2", facility_set={f2})
     workplace2.update_targeted_task_set({task2_1_1, task2_1_2, task2_2_1, task2_3})
 
-    project.update_workplace_set({workplace1, workplace2})
-
     # BaseTeams
-    team1 = BaseTeam("team1")
+    team1 = project.create_team("team1")
     team1.update_targeted_task_set({task1_1_1, task1_1_2, task1_2_1, task1_3})
-    worker11 = BaseWorker("w11", cost_per_time=10.0)
+    worker11 = team1.create_worker("w1", cost_per_time=10.0)
     worker11.workamount_skill_mean_map = {
         task1_1_1.name: 1.0,
         task1_1_2.name: 1.0,
@@ -193,11 +185,10 @@ def fixture_dummy_project_multiple():
         task1_3.name: 1.0,
     }
     worker11.facility_skill_map = {f1.name: 1.0}
-    team1.add_worker(worker11)
 
-    team2 = BaseTeam("team2")
+    team2 = project.create_team("team2")
     team2.update_targeted_task_set({task2_1_1, task2_1_2, task2_2_1, task2_3})
-    worker21 = BaseWorker("w2", cost_per_time=6.0)
+    worker21 = team2.create_worker("w2", cost_per_time=6.0)
     worker21.solo_working = True
     worker21.workamount_skill_mean_map = {
         task2_1_1.name: 1.0,
@@ -206,9 +197,6 @@ def fixture_dummy_project_multiple():
         task2_3.name: 1.0,
     }
     worker21.facility_skill_map = {f2.name: 1.0}
-    team2.add_worker(worker21)
-
-    project.update_team_set({team1, team2})
 
     project.initialize()
     return project


### PR DESCRIPTION
This pull request adds factory methods to the `BaseProject` class for creating and adding products, workflows, teams, and workplaces, and updates the test fixtures to use these new methods. It also introduces a method to associate target components with tasks, leading to cleaner and more maintainable code in both the core models and the test suite.

**Enhancements to `BaseProject` API:**

- Added `create_product`, `create_workflow`, `create_team`, and `create_workplace` methods to `BaseProject`, allowing direct creation and addition of these entities to the project in a single step. Each method provides detailed docstrings and handles optional parameters for easier and safer object construction. [[1]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR336-R353) [[2]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR382-R410) [[3]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR439-R472) [[4]](diffhunk://#diff-17557547b81dd0f529b5f2438a38a8b7cf080a21f7f3ee2e160dbb81f78d940cR501-R550)

**Task and Component Association:**

- Introduced `add_target_component` method to `BaseTask`, which sets the target component for a task and updates the component’s targeted task set accordingly.
- Added type checking import guard for `BaseComponent` in `base_task.py` to support type hints without circular import issues.

**Test Suite Refactoring:**

- Refactored `fixture_dummy_project_multiple` in `test_base_project.py` to use the new factory methods for creating products, workflows, teams, and workplaces, and to utilize the new `add_target_component` method for associating tasks and components. This results in more concise and readable test code. [[1]](diffhunk://#diff-9d7964630fe34043135004bf01fbb8d8dfbf6c1a11da850ce2fcc9f2619e4ab5L119-R191) [[2]](diffhunk://#diff-9d7964630fe34043135004bf01fbb8d8dfbf6c1a11da850ce2fcc9f2619e4ab5L209-L211)