### PR TITLE
The lines between components and tasks are not displayed in the project mermaid diagram.

### DIFF
--- a/pDESy/model/base_project.py
+++ b/pDESy/model/base_project.py
@@ -1855,7 +1855,7 @@ class BaseProject(object, metaclass=ABCMeta):
         Returns:
             set[BaseTask]: Set of tasks matching the provided IDs.
         """
-        if self.task_dict == {}:
+        if not self.task_dict:
             self.__initialize_child_instance_set_id_instance_dict()
         return {
             self.task_dict[tid] for tid in target_task_id_set if tid in self.task_dict


### PR DESCRIPTION
This pull request introduces two main changes: an improvement to the initialization logic in the `BaseProject` model. 

**Code logic improvement:**

* Updated the method `get_target_task_set` in `base_project.py` to automatically initialize child instance dictionaries if `task_dict` is empty, ensuring that task retrieval works reliably even when the internal state is uninitialized.